### PR TITLE
feat: improve `defaultDict` typing

### DIFF
--- a/packages/utils/src/default-dict.ts
+++ b/packages/utils/src/default-dict.ts
@@ -1,16 +1,15 @@
 // https://docs.python.org/3/library/collections.html#collections.defaultdict
 // https://stackoverflow.com/questions/19127650/defaultdict-equivalent-in-javascript
 
-export function defaultDict<T>(defaultFactory: () => T): Record<string, T> {
-  return new Proxy<Record<string, T>>(
-    {},
-    {
-      get: (target, p: string) => {
-        if (!(p in target)) {
-          target[p] = defaultFactory();
-        }
-        return target[p];
-      },
-    }
-  );
+export function defaultDict<K extends string, T>(
+  defaultFactory: () => T
+): Record<K, T> {
+  return new Proxy<Record<K, T>>({} as any, {
+    get: (target: any, p: any) => {
+      if (!(p in target)) {
+        target[p] = defaultFactory();
+      }
+      return target[p];
+    },
+  });
 }

--- a/packages/utils/src/index.test.ts
+++ b/packages/utils/src/index.test.ts
@@ -24,7 +24,7 @@ describe("booleanGuard", () => {
 
 describe("defaultDict", () => {
   it("basic", () => {
-    const record = defaultDict(() => [0]);
+    const record = defaultDict<string, number[]>(() => [0]);
 
     // `Proxy` itself breaks vitest snapshot with the following error message:
     //   PrettyFormatPluginError: val.getMockName is not a function


### PR DESCRIPTION
but `defaultMap` is the way to go, so `defaultDict` isn't really important anymore.