### PR TITLE
chore(utils-react): package without jsx-runtime

### DIFF
--- a/.changeset/nice-trees-cough.md
+++ b/.changeset/nice-trees-cough.md
@@ -1,0 +1,5 @@
+---
+"@hiogawa/utils-react": patch
+---
+
+chore(utils-react): package without jsx-runtime

--- a/packages/utils-react/src/debug.tsx
+++ b/packages/utils-react/src/debug.tsx
@@ -1,3 +1,5 @@
+import React from "react";
+
 export function Debug(
   props: { debug: unknown } & JSX.IntrinsicElements["details"]
 ) {

--- a/packages/utils-react/tsconfig.json
+++ b/packages/utils-react/tsconfig.json
@@ -7,6 +7,7 @@
     "module": "ESNext",
     "target": "ESNext",
     "lib": ["ESNext", "DOM"],
-    "jsx": "react-jsx"
+    // react-jsx would require tricky workaround in old react https://github.com/hi-ogawa/js-utils/issues/19
+    "jsx": "react"
   }
 }


### PR DESCRIPTION
- fixes https://github.com/hi-ogawa/js-utils/issues/19