### PR TITLE
feat: create utils-experimental package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
         options:
           - utils
           - utils-react
+          - utils-experimental
         default: utils
 jobs:
   release:

--- a/packages/utils-experimental/README.md
+++ b/packages/utils-experimental/README.md
@@ -1,0 +1,7 @@
+# utils-experimental
+
+```sh
+# publish
+pnpm build
+pnpm release
+```

--- a/packages/utils-experimental/package.json
+++ b/packages/utils-experimental/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/utils-experimental",
-  "version": "0.0.0-pre.0",
+  "version": "0.0.0",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/utils-experimental/package.json
+++ b/packages/utils-experimental/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@hiogawa/utils-experimental",
+  "version": "0.0.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/hi-ogawa/js-utils",
+    "directory": "packages/utils-experimental"
+  },
+  "typedoc": {
+    "displayName": "@hiogawa/utils",
+    "readmeFile": "./README.md",
+    "entryPoint": "./src/index.ts"
+  },
+  "scripts": {
+    "build": "tsup",
+    "test": "vitest",
+    "release": "pnpm publish --no-git-checks --access public"
+  }
+}

--- a/packages/utils-experimental/package.json
+++ b/packages/utils-experimental/package.json
@@ -10,6 +10,11 @@
       "import": "./dist/index.js",
       "require": "./dist/index.cjs",
       "types": "./dist/index.d.ts"
+    },
+    "./dist/theme-script.global.js": {
+      "import": "./dist/theme-script.global.js",
+      "require": "./dist/theme-script.global.js",
+      "types": "./dist/theme-script.global.ts"
     }
   },
   "files": [

--- a/packages/utils-experimental/package.json
+++ b/packages/utils-experimental/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/utils-experimental",
-  "version": "0.0.1-pre.0",
+  "version": "0.0.1",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/utils-experimental/package.json
+++ b/packages/utils-experimental/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/utils-experimental",
-  "version": "0.0.0",
+  "version": "0.0.0-pre.0",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",
@@ -22,7 +22,7 @@
     "directory": "packages/utils-experimental"
   },
   "typedoc": {
-    "displayName": "@hiogawa/utils",
+    "displayName": "@hiogawa/utils-experimental",
     "readmeFile": "./README.md",
     "entryPoint": "./src/index.ts"
   },

--- a/packages/utils-experimental/package.json
+++ b/packages/utils-experimental/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/utils-experimental",
-  "version": "0.0.0",
+  "version": "0.0.1-pre.0",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/utils-experimental/src/index.test.ts
+++ b/packages/utils-experimental/src/index.test.ts
@@ -1,0 +1,3 @@
+import { describe } from "vitest";
+
+describe.skip("utils-experimental");

--- a/packages/utils-experimental/src/theme-script.ts
+++ b/packages/utils-experimental/src/theme-script.ts
@@ -1,0 +1,50 @@
+const themeApi = globalThis as unknown as {
+  // user input
+  __themeStorageKey?: string;
+  __themeDefaultTheme?: string;
+  // exposed api
+  __themeSet: (theme: string) => void;
+  __themeGet: () => string;
+};
+
+const key = themeApi.__themeStorageKey ?? "theme-script";
+const defaultTheme = themeApi.__themeDefaultTheme || "system";
+const prefersDarkQuery = window.matchMedia("(prefers-color-scheme: dark)");
+
+function getTheme() {
+  return window.localStorage.getItem(key) || defaultTheme;
+}
+
+function setTheme(theme: string) {
+  window.localStorage.setItem(key, theme);
+  applyTheme();
+}
+
+function applyTheme() {
+  const theme = getTheme();
+  const derived =
+    theme === "system" ? (prefersDarkQuery.matches ? "dark" : "light") : theme;
+  disableTransitions(() => {
+    document.documentElement.classList.remove("dark", "light");
+    document.documentElement.classList.add(derived);
+  });
+}
+
+// https://paco.me/writing/disable-theme-transitions
+function disableTransitions(callback: () => void) {
+  const el = document.createElement("style");
+  el.innerHTML = "* { transition: none !important; }";
+  document.head.appendChild(el);
+  callback();
+  window.getComputedStyle(document.documentElement).transition; // force repaint
+  document.head.removeChild(el);
+}
+
+function initTheme() {
+  applyTheme();
+  prefersDarkQuery.addEventListener("change", applyTheme);
+  themeApi.__themeGet = getTheme;
+  themeApi.__themeSet = setTheme;
+}
+
+initTheme();

--- a/packages/utils-experimental/src/theme-script.ts
+++ b/packages/utils-experimental/src/theme-script.ts
@@ -1,14 +1,14 @@
 const themeApi = globalThis as unknown as {
-  // user input
+  // user config
   __themeStorageKey?: string;
-  __themeDefaultTheme?: string;
+  __themeDefault?: string;
   // exposed api
   __themeSet: (theme: string) => void;
   __themeGet: () => string;
 };
 
 const key = themeApi.__themeStorageKey ?? "theme-script";
-const defaultTheme = themeApi.__themeDefaultTheme || "system";
+const defaultTheme = themeApi.__themeDefault ?? "system";
 const prefersDarkQuery = window.matchMedia("(prefers-color-scheme: dark)");
 
 function getTheme() {

--- a/packages/utils-experimental/tsconfig.json
+++ b/packages/utils-experimental/tsconfig.json
@@ -9,6 +9,7 @@
     "moduleResolution": "Node",
     "module": "ESNext",
     "target": "ESNext",
-    "lib": ["ESNext"]
+    "lib": ["ESNext", "DOM"],
+    "types": []
   }
 }

--- a/packages/utils-experimental/tsconfig.json
+++ b/packages/utils-experimental/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "@tsconfig/strictest/tsconfig.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "outDir": "dist/tsc",
+    "noEmit": true,
+    "declaration": true,
+    "noUncheckedIndexedAccess": false,
+    "moduleResolution": "Node",
+    "module": "ESNext",
+    "target": "ESNext",
+    "lib": ["ESNext"]
+  }
+}

--- a/packages/utils-experimental/tsup.config.ts
+++ b/packages/utils-experimental/tsup.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm", "cjs"],
+  dts: true,
+});

--- a/packages/utils-experimental/tsup.config.ts
+++ b/packages/utils-experimental/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: ["src/index.ts"],
-  format: ["esm", "cjs"],
+  entry: ["./src/index.ts", "./src/theme-script.ts"],
+  format: ["esm", "cjs", "iife"],
   dts: true,
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,6 +37,8 @@ importers:
 
   packages/utils: {}
 
+  packages/utils-experimental: {}
+
   packages/utils-react:
     devDependencies:
       '@testing-library/jest-dom':

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,9 @@
       "path": "packages/utils"
     },
     {
+      "path": "packages/utils-experimental"
+    },
+    {
       "path": "packages/utils-react"
     }
   ]


### PR DESCRIPTION
It might make it easier to put random stuff compared to `utils` and `utils-react`.
Mainly just thinking about how we can put my personal "theme-script" in one place, which is currently copy-pasted in many repos.