### PR TITLE
feat(tiny-rpc): skip non-endpoint in handler

### DIFF
--- a/packages/tiny-rpc/src/e2e.test.ts
+++ b/packages/tiny-rpc/src/e2e.test.ts
@@ -94,7 +94,8 @@ describe("e2e", () => {
     const server = createServer(
       compose(
         contextProviderHandler(),
-        createTinyRpcHandler({ endpoint, routes })
+        createTinyRpcHandler({ endpoint, routes }),
+        () => new Response("tiny-rpc-skipped")
       )
     );
     const { url } = await startTestServer(server);
@@ -171,6 +172,11 @@ describe("e2e", () => {
       expect(e).toMatchInlineSnapshot("[Error: Invalid ID]");
       return true;
     });
+
+    // ignore non-endpoint
+    expect(
+      await fetch(url + "/non-endpoint").then((res) => res.text())
+    ).toMatchInlineSnapshot('"tiny-rpc-skipped"');
 
     server.close();
   });


### PR DESCRIPTION
This would make the integration slightly easier since currently it has to check `pathname` like this:

https://github.com/hi-ogawa/youtube-dl-web-v2/blob/e5a46c8ef066492d6797010e247a5b495f68b68a/packages/app/src/trpc/hattip.ts#L7-L27

```tsx
export function rpcHandler(): RequestHandler {
  const handler = createTinyRpcHandler({
    endpoint: RPC_ENDPOINT,
    routes: rpcRoutes,
    onError(e) {
      console.error(e);
      const span = trace.getActiveSpan();
      if (span) {
        span.setStatus({ code: SpanStatusCode.ERROR });
        span.recordException(e instanceof Error ? e : new Error());
      }
    },
  });
  return async (ctx) => {
    if (ctx.url.pathname.startsWith(RPC_ENDPOINT)) {
      return handler(ctx);
    }
    return ctx.next();
  };
}
```

This can become:

```tsx
export function rpcHandler(): RequestHandler {
  return createTinyRpcHandler({
    endpoint: RPC_ENDPOINT,
    routes: rpcRoutes,
    onError(e) {
      console.error(e);
      const span = trace.getActiveSpan();
      if (span) {
        span.setStatus({ code: SpanStatusCode.ERROR });
        span.recordException(e instanceof Error ? e : new Error());
      }
    },
  });
}
```