### PR TITLE
feat(experimental): add `loggerMiddleware`

### DIFF
--- a/packages/utils-experimental/src/index.test.ts
+++ b/packages/utils-experimental/src/index.test.ts
@@ -1,3 +1,0 @@
-import { describe } from "vitest";
-
-describe.skip("utils-experimental");

--- a/packages/utils-experimental/src/index.ts
+++ b/packages/utils-experimental/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./logger-middleware";

--- a/packages/utils-experimental/src/logger-middleware.test.ts
+++ b/packages/utils-experimental/src/logger-middleware.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { loggerMiddleware } from "./logger-middleware";
+
+describe(loggerMiddleware, () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("basic", async () => {
+    let logs: string[] = [];
+    const logger = loggerMiddleware({ log: (v) => logs.push(v) });
+
+    vi.setSystemTime(new Date("2020-02-02T00:00:00.000Z"));
+    await logger({
+      url: { pathname: "/test" },
+      request: { method: "GET" },
+      next: async () => {
+        vi.setSystemTime(new Date("2020-02-02T00:00:00.123Z"));
+        return new Response(null, { status: 200 });
+      },
+    });
+
+    expect(logs).toMatchInlineSnapshot(`
+      [
+        "  --> GET /test",
+        "  <-- GET /test 200 123ms",
+      ]
+    `);
+
+    vi.setSystemTime(new Date("2020-02-02T00:00:00.000Z"));
+    await logger({
+      url: { pathname: "/test2" },
+      request: { method: "POST" },
+      next: async () => {
+        vi.setSystemTime(new Date("2020-02-02T00:00:01.230Z"));
+        return new Response(null, { status: 302 });
+      },
+    });
+
+    expect(logs).toMatchInlineSnapshot(`
+      [
+        "  --> GET /test",
+        "  <-- GET /test 200 123ms",
+        "  --> POST /test2",
+        "  <-- POST /test2 302 1.2s",
+      ]
+    `);
+  });
+});

--- a/packages/utils-experimental/src/logger-middleware.ts
+++ b/packages/utils-experimental/src/logger-middleware.ts
@@ -1,0 +1,34 @@
+// porting hono's logger to hattip
+// https://github.com/honojs/hono/blob/a8ebb47dddf2297341ced144b7e7e32b79a4f850/src/middleware/logger/index.ts
+
+// compatible with hattip's RequestHandler
+export type LoggerMiddleware = (ctx: {
+  url: Pick<URL, "pathname">;
+  request: Pick<Request, "method">;
+  next: () => Promise<Response>;
+}) => Promise<Response>;
+
+export function loggerMiddleware(options?: {
+  log?: (v: string) => void;
+}): LoggerMiddleware {
+  const log = options?.log ?? console.log;
+
+  return async (ctx) => {
+    const method = ctx.request.method;
+    const pathname = ctx.url.pathname;
+
+    const startTime = Date.now();
+    log(`  --> ${method} ${pathname}`);
+
+    const res = await ctx.next();
+
+    const duration = formatDuration(Date.now() - startTime);
+    log(`  <-- ${method} ${pathname} ${res.status} ${duration}`);
+
+    return res;
+  };
+}
+
+function formatDuration(ms: number) {
+  return ms < 1000 ? `${Math.floor(ms)}ms` : `${(ms / 1000).toFixed(1)}s`;
+}


### PR DESCRIPTION
So far I've been borrowing hono's logger for hattip by:

https://github.com/hi-ogawa/vite-fullstack-example/blob/e7bb3b71ea4746a4817e040fc87d9ea171328396/src/server/hattip.ts#L51-L73

It's time to make something simple on my own.
For now in `utils-experimental`, but probably I'll need `utils-hattip` package or something.

Included in 
- https://github.com/hi-ogawa/youtube-dl-web-v2/pull/67