### PR TITLE
test(query-proxy): test infinite query

### DIFF
--- a/packages/query-proxy/package.json
+++ b/packages/query-proxy/package.json
@@ -32,6 +32,7 @@
     "release": "pnpm publish --no-git-checks --access public"
   },
   "devDependencies": {
+    "@hiogawa/utils": "workspace:*",
     "@tanstack/query-core": "^4.29.14",
     "@trpc/client": "^10.33.0",
     "@trpc/server": "^10.33.0",

--- a/packages/query-proxy/src/record.ts
+++ b/packages/query-proxy/src/record.ts
@@ -50,7 +50,7 @@ export function createFnRecordQueryProxy<T extends FnRecord>(
       }
       if (prop === "queryOptions") {
         return (input: unknown) => ({
-          queryKey: [k, input],
+          queryKey: [k, input], // TODO: maybe strip if `input = undefined`?
           queryFn: async () => (fnRecord as any)[k](input),
         });
       }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,7 +42,7 @@ importers:
   packages/query-proxy:
     devDependencies:
       '@hiogawa/utils':
-        specifier: workspace:1.4.2-pre.13
+        specifier: workspace:*
         version: link:../utils
       '@tanstack/query-core':
         specifier: ^4.29.14

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
 
   packages/query-proxy:
     devDependencies:
+      '@hiogawa/utils':
+        specifier: workspace:1.4.2-pre.13
+        version: link:../utils
       '@tanstack/query-core':
         specifier: ^4.29.14
         version: 4.29.19


### PR DESCRIPTION
Hoping to remove typing peerDep of `@tanstack/query-core` by changing `FnRecordQueryProxy` api, but before that, let's add simple tests.