### PR TITLE
refactor(query-proxy): simplify `infiniteQueryOptions` proxy

### DIFF
--- a/packages/query-proxy/package.json
+++ b/packages/query-proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/query-proxy",
-  "version": "0.1.1-pre.0",
+  "version": "0.1.1-pre.1",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/query-proxy/package.json
+++ b/packages/query-proxy/package.json
@@ -39,7 +39,6 @@
     "zod": "^3.21.4"
   },
   "peerDependencies": {
-    "@tanstack/query-core": "*",
     "@trpc/server": "*"
   },
   "peerDependenciesMeta": {

--- a/packages/query-proxy/src/record.test.ts
+++ b/packages/query-proxy/src/record.test.ts
@@ -71,21 +71,13 @@ describe(createFnRecordQueryProxy.name, () => {
     // infinite query
     //
 
-    const infiniteQueryObserver = new InfiniteQueryObserver(
-      queryClient,
-      fnRecordQuery.getPage.infiniteQueryOptions(
-        {
-          limit: 5,
-        },
-        {
-          getNextPageParam: (lastPage) => lastPage.nextCursor,
-          setPageParam: (input, pageParam) => ({
-            ...input,
-            cursor: pageParam as any,
-          }),
-        }
-      )
-    );
+    const infiniteQueryObserver = new InfiniteQueryObserver(queryClient, {
+      ...fnRecordQuery.getPage.infiniteQueryOptions((context: any) => ({
+        limit: 5,
+        cursor: context?.pageParam,
+      })),
+      getNextPageParam: (lastPage) => lastPage.nextCursor,
+    });
 
     expect((await infiniteQueryObserver.fetchNextPage()).data)
       .toMatchInlineSnapshot(`
@@ -248,6 +240,7 @@ describe(createFnRecordQueryProxy.name, () => {
           "queryKey": [
             "getPage",
             {
+              "cursor": undefined,
               "limit": 5,
             },
           ],


### PR DESCRIPTION
Removing peer-deps of `@tanstack/query-core` by slightly generalizing `infiniteQueryOptions` construction.