### PR TITLE
feat(utils): add `wrapErrorAsync`

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/utils",
-  "version": "1.4.2-pre.13",
+  "version": "1.4.2-pre.14",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/utils/src/index.test.ts
+++ b/packages/utils/src/index.test.ts
@@ -12,7 +12,7 @@ import {
   type Result,
   okToOption,
   wrapError,
-  wrapPromise,
+  wrapErrorAsync,
 } from "./result";
 import { tinyassert } from "./tinyassert";
 
@@ -333,7 +333,7 @@ describe("Result", () => {
     });
   });
 
-  describe("wrapPromise", async () => {
+  describe(wrapErrorAsync, async () => {
     async function boom(value: boolean) {
       if (value) {
         throw new Error("boom");
@@ -342,7 +342,7 @@ describe("Result", () => {
     }
 
     it("success", async () => {
-      const result = await wrapPromise(boom(false));
+      const result = await wrapErrorAsync(() => boom(false));
       result satisfies Result<number, unknown>;
       expect(result).toMatchInlineSnapshot(`
         {
@@ -353,7 +353,7 @@ describe("Result", () => {
     });
 
     it("error", async () => {
-      const result = await wrapPromise(boom(true));
+      const result = await wrapErrorAsync(() => boom(true));
       result satisfies Result<number, unknown>;
       expect(result).toMatchInlineSnapshot(`
         {
@@ -386,7 +386,7 @@ describe("newPromiseWithResolvers", () => {
   it("resolve", async () => {
     const { promise, resolve } = newPromiseWithResolvers<number>();
     resolve(123);
-    const result = await wrapPromise(promise);
+    const result = await wrapErrorAsync(() => promise);
     expect(result).toMatchInlineSnapshot(`
       {
         "ok": true,
@@ -398,7 +398,7 @@ describe("newPromiseWithResolvers", () => {
   it("reject", async () => {
     const { promise, reject } = newPromiseWithResolvers<number>();
     reject(123);
-    const result = await wrapPromise(promise);
+    const result = await wrapErrorAsync(() => promise);
     expect(result).toMatchInlineSnapshot(`
       {
         "ok": false,

--- a/packages/utils/src/result.ts
+++ b/packages/utils/src/result.ts
@@ -18,10 +18,23 @@ export function wrapError<T>(getValue: () => T): Result<T, unknown> {
   }
 }
 
+export async function wrapErrorAsync<T>(
+  getValue: () => Promise<T>
+): Promise<Result<T, unknown>> {
+  try {
+    return Ok(await getValue());
+  } catch (e) {
+    return Err(e);
+  }
+}
+
 export function okToOption<T>(result: Result<T, unknown>): T | undefined {
   return result.ok ? result.value : undefined;
 }
 
+/**
+ * @deprecated use `wrapErrorAsync` instead
+ */
 export async function wrapPromise<T>(
   value: Promise<T>
 ): Promise<Result<T, unknown>> {


### PR DESCRIPTION
Replacing `wrapPromise` with `wrapErrorAsync` since it doesn't feel well balanced with `wrapError`.