### PR TITLE
feat(utils): add `arrayToEnum`

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/utils",
-  "version": "1.4.2-pre.14",
+  "version": "1.4.2-pre.15",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/utils/src/index.test.ts
+++ b/packages/utils/src/index.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { defaultDict } from "./default-dict";
 import { DefaultMap, HashKeyDefaultMap, UncheckedMap } from "./default-map";
 import { groupBy, range } from "./lodash";
-import { assertUnreachable, typedBoolean } from "./misc";
+import { arrayToEnum, assertUnreachable, typedBoolean } from "./misc";
 import { mapOption } from "./option";
 import { newPromiseWithResolvers } from "./promise";
 import { escapeRegExp, mapRegExp, regExpRaw } from "./regexp";
@@ -31,6 +31,80 @@ describe("typedBoolean", () => {
     const result1 = someArray.filter(Boolean);
     const result2 = someArray.filter(typedBoolean) satisfies { x: number }[];
     expect(result1).toEqual(result2);
+  });
+});
+
+describe(arrayToEnum, () => {
+  it("basic", () => {
+    const e = arrayToEnum(["x", "y"]);
+    e satisfies {
+      x: "x";
+      y: "y";
+    };
+    expect(e).toMatchInlineSnapshot(`
+      {
+        "x": "x",
+        "y": "y",
+      }
+    `);
+  });
+
+  it("const", () => {
+    const src = ["x", "y"] as const;
+    const e = arrayToEnum(src);
+    e satisfies {
+      x: "x";
+      y: "y";
+    };
+    expect(e).toMatchInlineSnapshot(`
+      {
+        "x": "x",
+        "y": "y",
+      }
+    `);
+  });
+
+  it("destructure", () => {
+    const src = ["x", "y"] as const;
+    const e = arrayToEnum(["w", ...src, "z"]);
+    e satisfies {
+      w: "w";
+      x: "x";
+      y: "y";
+      z: "z";
+    };
+    expect(e).toMatchInlineSnapshot(`
+      {
+        "w": "w",
+        "x": "x",
+        "y": "y",
+        "z": "z",
+      }
+    `);
+  });
+
+  it("number", () => {
+    const s = Symbol("s");
+    const e = arrayToEnum([0, 1, "x", "y", s]);
+    e satisfies {
+      0: 0;
+      1: 1;
+      x: "x";
+      y: "y";
+      [s]: typeof s;
+    };
+    expect(e).toMatchInlineSnapshot(`
+      {
+        "0": 0,
+        "1": 1,
+        "x": "x",
+        "y": "y",
+        Symbol(s): Symbol(s),
+      }
+    `);
+    expect(e[0]).toMatchInlineSnapshot("0");
+    expect(e.x).toMatchInlineSnapshot('"x"');
+    expect(e[s]).toMatchInlineSnapshot("Symbol(s)");
   });
 });
 

--- a/packages/utils/src/misc.ts
+++ b/packages/utils/src/misc.ts
@@ -21,3 +21,16 @@ export function flattenErrorCauses(e: unknown): unknown[] {
   }
   return errors;
 }
+
+// similar convenience as z.enum but supports any key (number | string | symbol)
+// cf. https://github.com/colinhacks/zod/blob/cfbc7b3f6714ced250dd4053822faf472bf1828e/src/types.ts#L3958
+export function arrayToEnum<
+  T extends keyof any,
+  Ts extends Readonly<[T, ...T[]]>
+>(
+  values: Ts
+): {
+  [K in Ts[number]]: K;
+} {
+  return Object.fromEntries(values.map((v) => [v, v])) as any;
+}


### PR DESCRIPTION
It often happens that wishing to use `z.enum` to manage constants without typo but then most of the case you wouldn't want a whole zod.
So, here adding simple and quick alternative.
It also turns out that it can naturally support all `number | string | symbol` constants.