### PR TITLE
feat(utils): add `mapToAsyncGenerator`

### DIFF
--- a/packages/utils/src/index.test.ts
+++ b/packages/utils/src/index.test.ts
@@ -572,26 +572,72 @@ describe(mapRegExp.name, () => {
   });
 });
 
-describe(mapPromise, () => {
-  const sleep = (ms: number) =>
-    new Promise((resolve) => setTimeout(resolve, ms));
+describe.only(mapPromise, () => {
+  function sleep(ms: number) {
+    return new Promise((resolve) => setTimeout(() => resolve(null), ms));
+  }
 
   it("basic", async () => {
     const logs: any[] = [];
-    const results = await mapPromise(
+    const gen = mapPromise(
       range(10).reverse(),
-      async (i) => {
-        console.log("->", i);
-        logs.push(`-> ${i}`);
-        await sleep(i * 10);
-        console.log("<-", i);
-        logs.push(`<- ${i}`);
+      async (v, i) => {
+        await sleep(v * 100);
+        return { v, i };
       },
       {
         concurrency: 3,
       }
     );
-    expect(results).toMatchInlineSnapshot();
-    expect(logs).toMatchInlineSnapshot();
+
+    let results: any[] = [];
+    for await (const v of gen) {
+      results.push(v);
+    }
+    expect(results).toMatchInlineSnapshot(`
+      [
+        {
+          "i": 2,
+          "v": 7,
+        },
+        {
+          "i": 1,
+          "v": 8,
+        },
+        {
+          "i": 0,
+          "v": 9,
+        },
+        {
+          "i": 5,
+          "v": 4,
+        },
+        {
+          "i": 3,
+          "v": 6,
+        },
+        {
+          "i": 4,
+          "v": 5,
+        },
+        {
+          "i": 8,
+          "v": 1,
+        },
+        {
+          "i": 9,
+          "v": 0,
+        },
+        {
+          "i": 7,
+          "v": 2,
+        },
+        {
+          "i": 6,
+          "v": 3,
+        },
+      ]
+    `);
+    expect(logs).toMatchInlineSnapshot("[]");
   });
 });

--- a/packages/utils/src/index.test.ts
+++ b/packages/utils/src/index.test.ts
@@ -4,7 +4,7 @@ import { DefaultMap, HashKeyDefaultMap, UncheckedMap } from "./default-map";
 import { groupBy, range } from "./lodash";
 import { arrayToEnum, assertUnreachable, typedBoolean } from "./misc";
 import { mapOption } from "./option";
-import { mapPromise, newPromiseWithResolvers } from "./promise";
+import { mapToAsyncGenerator, newPromiseWithResolvers } from "./promise";
 import { escapeRegExp, mapRegExp, regExpRaw } from "./regexp";
 import {
   Err,
@@ -572,7 +572,7 @@ describe(mapRegExp.name, () => {
   });
 });
 
-describe(mapPromise, () => {
+describe(mapToAsyncGenerator, () => {
   function sleep(ms: number) {
     return new Promise((resolve) => setTimeout(() => resolve(null), ms));
   }
@@ -588,7 +588,7 @@ describe(mapPromise, () => {
   }
 
   it("basic", async () => {
-    const generator = mapPromise(
+    const generator = mapToAsyncGenerator(
       range(5).reverse(),
       async (v, i) => {
         await sleep(50);
@@ -627,7 +627,7 @@ describe(mapPromise, () => {
   });
 
   it("synchronous", async () => {
-    const generator = mapPromise(
+    const generator = mapToAsyncGenerator(
       range(5).reverse(),
       (v, i) => {
         return { v, i };
@@ -665,7 +665,7 @@ describe(mapPromise, () => {
   });
 
   it("error", async () => {
-    const generator = mapPromise(
+    const generator = mapToAsyncGenerator(
       range(5),
       async (v) => {
         await sleep(50);
@@ -707,7 +707,7 @@ describe(mapPromise, () => {
 
     const result: unknown[] = [];
 
-    const generator = mapPromise(
+    const generator = mapToAsyncGenerator(
       range(5).reverse(),
       async (v, i) => {
         sleep(v * 30);

--- a/packages/utils/src/index.test.ts
+++ b/packages/utils/src/index.test.ts
@@ -4,7 +4,7 @@ import { DefaultMap, HashKeyDefaultMap, UncheckedMap } from "./default-map";
 import { groupBy, range } from "./lodash";
 import { arrayToEnum, assertUnreachable, typedBoolean } from "./misc";
 import { mapOption } from "./option";
-import { newPromiseWithResolvers } from "./promise";
+import { mapPromise, newPromiseWithResolvers } from "./promise";
 import { escapeRegExp, mapRegExp, regExpRaw } from "./regexp";
 import {
   Err,
@@ -569,5 +569,29 @@ describe(mapRegExp.name, () => {
     expect(transform("x = {{ 1 + 2 }}, y = {{ 4 * 5 }}")).toMatchInlineSnapshot(
       '"x = 3, y = 20"'
     );
+  });
+});
+
+describe(mapPromise, () => {
+  const sleep = (ms: number) =>
+    new Promise((resolve) => setTimeout(resolve, ms));
+
+  it("basic", async () => {
+    const logs: any[] = [];
+    const results = await mapPromise(
+      range(10).reverse(),
+      async (i) => {
+        console.log("->", i);
+        logs.push(`-> ${i}`);
+        await sleep(i * 10);
+        console.log("<-", i);
+        logs.push(`<- ${i}`);
+      },
+      {
+        concurrency: 3,
+      }
+    );
+    expect(results).toMatchInlineSnapshot();
+    expect(logs).toMatchInlineSnapshot();
   });
 });

--- a/packages/utils/src/index.test.ts
+++ b/packages/utils/src/index.test.ts
@@ -572,7 +572,7 @@ describe(mapRegExp.name, () => {
   });
 });
 
-describe.only(mapPromise, () => {
+describe(mapPromise, () => {
   function sleep(ms: number) {
     return new Promise((resolve) => setTimeout(() => resolve(null), ms));
   }
@@ -580,7 +580,7 @@ describe.only(mapPromise, () => {
   it("basic", async () => {
     const logs: any[] = [];
     const gen = mapPromise(
-      range(10).reverse(),
+      range(8),
       async (v, i) => {
         await sleep(v * 100);
         return { v, i };
@@ -597,44 +597,36 @@ describe.only(mapPromise, () => {
     expect(results).toMatchInlineSnapshot(`
       [
         {
-          "i": 2,
-          "v": 7,
-        },
-        {
-          "i": 1,
-          "v": 8,
-        },
-        {
           "i": 0,
-          "v": 9,
-        },
-        {
-          "i": 5,
-          "v": 4,
-        },
-        {
-          "i": 3,
-          "v": 6,
-        },
-        {
-          "i": 4,
-          "v": 5,
-        },
-        {
-          "i": 8,
-          "v": 1,
-        },
-        {
-          "i": 9,
           "v": 0,
         },
         {
-          "i": 7,
+          "i": 1,
+          "v": 1,
+        },
+        {
+          "i": 2,
           "v": 2,
         },
         {
-          "i": 6,
+          "i": 3,
           "v": 3,
+        },
+        {
+          "i": 4,
+          "v": 4,
+        },
+        {
+          "i": 5,
+          "v": 5,
+        },
+        {
+          "i": 6,
+          "v": 6,
+        },
+        {
+          "i": 7,
+          "v": 7,
         },
       ]
     `);

--- a/packages/utils/src/promise.ts
+++ b/packages/utils/src/promise.ts
@@ -19,6 +19,7 @@ export async function* mapToAsyncGenerator<T1, T2>(
   let index = 0;
   for (const value of values) {
     if (pendings.length >= concurrency) {
+      // TODO: find and yield other resolved promises after Promise.race?
       yield (await Promise.race(pendings))();
     }
 

--- a/packages/utils/src/promise.ts
+++ b/packages/utils/src/promise.ts
@@ -9,81 +9,35 @@ export function newPromiseWithResolvers<T>() {
 }
 
 // similar to http://bluebirdjs.com/docs/api/promise.map.html
-export async function mapPromise<T1, T2>(
-  ls: Iterable<T1>,
-  f: (v: T1) => PromiseLike<T2>,
-  { concurrency }: { concurrency: number }
-): Promise<T2[]> {
-  const queue = new AsyncTaskQueue<T2>({ concurrency });
-  for (const v of ls) {
-    await queue.put(() => f(v));
-  }
-  await queue.join();
-  return queue.results;
-}
-
-export async function* mapPromise2<T1, T2>(
-  ls: Iterable<T1>,
-  f: (v: T1) => PromiseLike<T2>,
+export async function* mapPromise<T1, T2>(
+  values: Iterable<T1>,
+  f: (value: T1, index: number) => PromiseLike<T2>,
   { concurrency }: { concurrency: number }
 ): AsyncGenerator<T2> {
-  const pendings: Promise<[number, T2]>[] = [];
+  const pendings = new Map<number, Promise<[number, T2]>>();
 
   async function consumePending() {
-    const [iDone, result] = await Promise.any(pendings);
-    pendings.splice(iDone, 1);
+    const [key, result] = await Promise.race(pendings.values());
+    pendings.delete(key);
     return result;
   }
 
-  for (const v of ls) {
-    if (pendings.length >= concurrency) {
+  let index = 0;
+  for (const value of values) {
+    if (pendings.size >= concurrency) {
       yield await consumePending();
     }
-    const iPending = pendings.length;
-    pendings.push(
+    const key = index++;
+    pendings.set(
+      key,
       (async () => {
-        const result = await f(v);
-        return [iPending, result];
+        const result = await f(value, key);
+        return [key, result];
       })()
     );
   }
 
-  while (pendings.length > 0) {
+  while (pendings.size > 0) {
     yield await consumePending();
-  }
-}
-
-class AsyncTaskQueue<T> {
-  pending: Promise<number>[] = [];
-  results: T[] = [];
-
-  constructor(private options: { concurrency: number }) {}
-
-  async put(fn: () => PromiseLike<T>) {
-    if (this.pending.length >= this.options.concurrency) {
-      await this.consumePending();
-    }
-
-    const iResult = this.results.length;
-    this.results[iResult] = undefined!;
-
-    const iPending = this.pending.length;
-    console.log("== put", { iResult, iPending });
-    this.pending[iPending] = (async () => {
-      this.results[iResult] = await fn();
-      return iPending;
-    })();
-  }
-
-  private async consumePending() {
-    const iPending = await Promise.any(this.pending);
-    console.log("== consumePending", { iPending });
-    this.pending.splice(iPending, 1);
-  }
-
-  async join() {
-    while (this.pending.length > 0) {
-      await this.consumePending();
-    }
   }
 }

--- a/packages/utils/src/promise.ts
+++ b/packages/utils/src/promise.ts
@@ -11,28 +11,29 @@ export function newPromiseWithResolvers<T>() {
 // similar to http://bluebirdjs.com/docs/api/promise.map.html
 export async function* mapPromise<T1, T2>(
   values: Iterable<T1>,
-  f: (value: T1, index: number) => PromiseLike<T2>,
+  f: (value: T1, index: number) => T2 | PromiseLike<T2>,
   { concurrency }: { concurrency: number }
 ): AsyncGenerator<T2> {
-  const pendings: Promise<T2>[] = [];
+  const pendings: Promise<() => T2>[] = [];
 
   let index = 0;
   for (const value of values) {
     if (pendings.length >= concurrency) {
-      yield await Promise.race(pendings);
+      yield (await Promise.race(pendings))();
     }
 
     const promise = (async () => {
       const result = await f(value, index++);
-      // `await f(...)` allows ticks for `pendings.push`
-      // TODO: is this guaranteed by ecmascript spec? or implementation dependent?
-      pendings.splice(pendings.indexOf(promise!), 1);
-      return result;
+      return () => {
+        // cleanup itself and get result
+        pendings.splice(pendings.indexOf(promise), 1);
+        return result;
+      };
     })();
     pendings.push(promise);
   }
 
   while (pendings.length > 0) {
-    yield await Promise.race(pendings);
+    yield (await Promise.race(pendings))();
   }
 }

--- a/packages/utils/src/promise.ts
+++ b/packages/utils/src/promise.ts
@@ -7,3 +7,83 @@ export function newPromiseWithResolvers<T>() {
   });
   return { promise, resolve, reject };
 }
+
+// similar to http://bluebirdjs.com/docs/api/promise.map.html
+export async function mapPromise<T1, T2>(
+  ls: Iterable<T1>,
+  f: (v: T1) => PromiseLike<T2>,
+  { concurrency }: { concurrency: number }
+): Promise<T2[]> {
+  const queue = new AsyncTaskQueue<T2>({ concurrency });
+  for (const v of ls) {
+    await queue.put(() => f(v));
+  }
+  await queue.join();
+  return queue.results;
+}
+
+export async function* mapPromise2<T1, T2>(
+  ls: Iterable<T1>,
+  f: (v: T1) => PromiseLike<T2>,
+  { concurrency }: { concurrency: number }
+): AsyncGenerator<T2> {
+  const pendings: Promise<[number, T2]>[] = [];
+
+  async function consumePending() {
+    const [iDone, result] = await Promise.any(pendings);
+    pendings.splice(iDone, 1);
+    return result;
+  }
+
+  for (const v of ls) {
+    if (pendings.length >= concurrency) {
+      yield await consumePending();
+    }
+    const iPending = pendings.length;
+    pendings.push(
+      (async () => {
+        const result = await f(v);
+        return [iPending, result];
+      })()
+    );
+  }
+
+  while (pendings.length > 0) {
+    yield await consumePending();
+  }
+}
+
+class AsyncTaskQueue<T> {
+  pending: Promise<number>[] = [];
+  results: T[] = [];
+
+  constructor(private options: { concurrency: number }) {}
+
+  async put(fn: () => PromiseLike<T>) {
+    if (this.pending.length >= this.options.concurrency) {
+      await this.consumePending();
+    }
+
+    const iResult = this.results.length;
+    this.results[iResult] = undefined!;
+
+    const iPending = this.pending.length;
+    console.log("== put", { iResult, iPending });
+    this.pending[iPending] = (async () => {
+      this.results[iResult] = await fn();
+      return iPending;
+    })();
+  }
+
+  private async consumePending() {
+    const iPending = await Promise.any(this.pending);
+    console.log("== consumePending", { iPending });
+    this.pending.splice(iPending, 1);
+  }
+
+  async join() {
+    while (this.pending.length > 0) {
+      await this.consumePending();
+    }
+  }
+}

--- a/packages/utils/src/promise.ts
+++ b/packages/utils/src/promise.ts
@@ -25,7 +25,7 @@ export async function* mapPromise<T1, T2>(
     const promise = (async () => {
       const result = await f(value, index++);
       return () => {
-        // cleanup itself and get result
+        // synchronously cleanup itself then return
         pendings.splice(pendings.indexOf(promise), 1);
         return result;
       };

--- a/packages/utils/src/promise.ts
+++ b/packages/utils/src/promise.ts
@@ -37,3 +37,13 @@ export async function* mapToAsyncGenerator<T1, T2>(
     yield (await Promise.race(pendings))();
   }
 }
+
+export async function arrayFromAsyncGenerator<T>(
+  generator: AsyncGenerator<T>
+): Promise<T[]> {
+  const result: T[] = [];
+  for await (const v of generator) {
+    result.push(v);
+  }
+  return result;
+}

--- a/packages/utils/src/promise.ts
+++ b/packages/utils/src/promise.ts
@@ -15,27 +15,39 @@ export async function* mapToAsyncGenerator<T1, T2>(
   { concurrency }: { concurrency: number }
 ): AsyncGenerator<T2> {
   const pendings: Promise<() => T2>[] = [];
+  const ready: Promise<() => T2>[] = [];
 
   let index = 0;
   for (const value of values) {
     if (pendings.length >= concurrency) {
-      // TODO: find and yield other resolved promises after Promise.race?
       yield (await Promise.race(pendings))();
+
+      // also flush "ready" promises
+      for (const res of await Promise.all(ready)) {
+        yield res();
+      }
     }
 
-    const promise = (async () => {
+    const { promise, resolve, reject } = newPromiseWithResolvers<() => T2>();
+    (async () => {
       const result = await f(value, index++);
+      ready.push(promise); // TODO: would this help slight optimization?
       return () => {
         // synchronously cleanup itself then return
         pendings.splice(pendings.indexOf(promise), 1);
+        ready.splice(ready.indexOf(promise), 1);
         return result;
       };
-    })();
+    })().then(resolve, reject);
     pendings.push(promise);
   }
 
   while (pendings.length > 0) {
     yield (await Promise.race(pendings))();
+
+    for (const res of await Promise.all(ready)) {
+      yield res();
+    }
   }
 }
 

--- a/packages/utils/src/promise.ts
+++ b/packages/utils/src/promise.ts
@@ -8,8 +8,8 @@ export function newPromiseWithResolvers<T>() {
   return { promise, resolve, reject };
 }
 
-// similar to http://bluebirdjs.com/docs/api/promise.map.html
-export async function* mapPromise<T1, T2>(
+// somewhat more flexible variant of http://bluebirdjs.com/docs/api/promise.map.html
+export async function* mapToAsyncGenerator<T1, T2>(
   values: Iterable<T1>,
   f: (value: T1, index: number) => T2 | PromiseLike<T2>,
   { concurrency }: { concurrency: number }


### PR DESCRIPTION
I was wondering how I would implement bluebird's `Promise.map` http://bluebirdjs.com/docs/api/promise.map.html
It was quite interesting exploration and ended up with this. (self-referential promise?)

## todo

- [x] better test cases