### PR TITLE
feat(tiny-cli): add `tinyCliMain`

### DIFF
--- a/.changeset/itchy-mice-fry.md
+++ b/.changeset/itchy-mice-fry.md
@@ -1,0 +1,5 @@
+---
+"@hiogawa/tiny-cli": minor
+---
+
+feat: add `tinyCliMain`

--- a/packages/tiny-cli/README.md
+++ b/packages/tiny-cli/README.md
@@ -13,6 +13,7 @@ simple type-safe command line parsing library
 
 ## not supported
 
+- short form option e.g. `-h`
 - command option alias
 - transform option key from kebab-case to camelCase
 - special arguments e.g. `--`

--- a/packages/tiny-cli/README.md
+++ b/packages/tiny-cli/README.md
@@ -20,6 +20,7 @@ simple type-safe command line parsing library
 
 ## examples
 
+- https://github.com/hi-ogawa/js-utils/blob/cbc39056a8221463f1b90cf61c411f1037f17ab4/packages/tiny-jwt/src/cli-node.ts
 - https://github.com/hi-ogawa/isort-ts/blob/dc95b781cde4b5c7998fc69219fb11eaf055a339/src/cli.ts
 - https://github.com/hi-ogawa/ytsub-v3/blob/08e3aed9a8be3472c7b4d0f61a978e546c75eeb8/app/misc/cli.ts
 - see also various tests `./src/*.test.ts`

--- a/packages/tiny-cli/package.json
+++ b/packages/tiny-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/tiny-cli",
-  "version": "0.0.3",
+  "version": "0.0.4-pre.0",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/tiny-cli/package.json
+++ b/packages/tiny-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/tiny-cli",
-  "version": "0.0.4-pre.0",
+  "version": "0.0.4-pre.1",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/tiny-cli/src/index.ts
+++ b/packages/tiny-cli/src/index.ts
@@ -3,3 +3,4 @@ export * from "./presets";
 export * from "./zod";
 export { TinyCliParseError } from "./utils";
 export { type ArgSchema, type ArgSchemaRecord, type TypedArgs } from "./typed";
+export * from "./main";

--- a/packages/tiny-cli/src/main.ts
+++ b/packages/tiny-cli/src/main.ts
@@ -1,18 +1,23 @@
-import process from "node:process";
 import { Err, Ok, type Result, formatError } from "@hiogawa/utils";
 import type { TinyCli, TinyCliCommand } from "./cli";
 import { TinyCliParseError } from "./utils";
 
 export async function tinyCliMain(
-  cli: TinyCli | TinyCliCommand<any>
+  cli: TinyCli | TinyCliCommand<any>,
+  opts?: {
+    process?: Pick<(typeof globalThis)["process"], "argv" | "exitCode">;
+    log?: (v: string) => void;
+  }
 ): Promise<Result<unknown, unknown>> {
+  const process = opts?.process ?? globalThis.process;
+  const log = opts?.log ?? globalThis.console.log;
   try {
     const v = await cli.parse(process.argv.slice(2));
     return Ok(v);
   } catch (e) {
-    console.error(formatError(e));
+    log(formatError(e));
     if (e instanceof TinyCliParseError) {
-      console.log("See '--help' for more info");
+      log("See '--help' for more info");
     }
     process.exitCode = 1;
     return Err(e);

--- a/packages/tiny-cli/src/main.ts
+++ b/packages/tiny-cli/src/main.ts
@@ -5,10 +5,15 @@ import { TinyCliParseError } from "./utils";
 export async function tinyCliMain(
   cli: TinyCli | TinyCliCommand<any>,
   opts?: {
-    process?: Pick<(typeof globalThis)["process"], "argv" | "exitCode">;
+    // assumes NodeJS.Process but avoid direct type dep
+    process?: {
+      argv: string[];
+      exitCode?: number | undefined;
+    };
     log?: (v: string) => void;
   }
 ): Promise<Result<unknown, unknown>> {
+  // @ts-ignore silence type error on tsup
   const process = opts?.process ?? globalThis.process;
   const log = opts?.log ?? globalThis.console.log;
   try {

--- a/packages/tiny-cli/src/main.ts
+++ b/packages/tiny-cli/src/main.ts
@@ -15,7 +15,7 @@ export async function tinyCliMain(
 ): Promise<Result<unknown, unknown>> {
   // @ts-ignore silence type error on tsup
   const process = opts?.process ?? globalThis.process;
-  const log = opts?.log ?? globalThis.console.log;
+  const log = opts?.log ?? globalThis.console.error;
   try {
     const v = await cli.parse(process.argv.slice(2));
     return Ok(v);

--- a/packages/tiny-cli/src/node.ts
+++ b/packages/tiny-cli/src/node.ts
@@ -1,0 +1,20 @@
+import process from "node:process";
+import { Err, Ok, type Result, formatError } from "@hiogawa/utils";
+import type { TinyCli, TinyCliCommand } from "./cli";
+import { TinyCliParseError } from "./utils";
+
+export async function tinyCliMain(
+  cli: TinyCli | TinyCliCommand<any>
+): Promise<Result<unknown, unknown>> {
+  try {
+    const v = await cli.parse(process.argv.slice(2));
+    return Ok(v);
+  } catch (e) {
+    console.error(formatError(e));
+    if (e instanceof TinyCliParseError) {
+      console.log("See '--help' for more info");
+    }
+    process.exitCode = 1;
+    return Err(e);
+  }
+}

--- a/packages/tiny-jwt/src/cli-node.ts
+++ b/packages/tiny-jwt/src/cli-node.ts
@@ -1,7 +1,10 @@
 import "./polyfill-node";
-import process from "node:process";
-import { TinyCli, TinyCliParseError, arg } from "@hiogawa/tiny-cli";
-import { formatError } from "@hiogawa/utils";
+import {
+  TinyCli,
+  TinyCliParseError,
+  arg,
+  tinyCliMain,
+} from "@hiogawa/tiny-cli";
 import { version } from "../package.json";
 
 const cli = new TinyCli({
@@ -69,16 +72,4 @@ cli.defineCommand(
 // main
 //
 
-async function main() {
-  try {
-    await cli.parse(process.argv.slice(2));
-  } catch (e) {
-    console.log(formatError(e, { noColor: !process.stdout.isTTY }));
-    if (e instanceof TinyCliParseError) {
-      console.log("See '--help' for more info.\n\n" + cli.help());
-    }
-    process.exit(1);
-  }
-}
-
-main();
+tinyCliMain(cli);


### PR DESCRIPTION
A little helper for environment with `globalThis.process` to save common boilerplate.