### PR TITLE
chore(theme-script): remove unused options

### DIFF
--- a/.changeset/dull-eagles-roll.md
+++ b/.changeset/dull-eagles-roll.md
@@ -1,0 +1,5 @@
+---
+"@hiogawa/theme-script": patch
+---
+
+chore: cleanup unused options

--- a/packages/theme-script/src/vite.ts
+++ b/packages/theme-script/src/vite.ts
@@ -2,7 +2,9 @@ import { type Plugin } from "vite";
 import { type ThemeScriptOptions, generateThemeScript } from ".";
 
 // inject raw script into html head to initialize style as early as possible
-export function themeScriptPlugin(options?: ThemeScriptOptions): Plugin {
+export function themeScriptPlugin(
+  options?: Omit<ThemeScriptOptions, "noScriptTag">
+): Plugin {
   return {
     name: "@hiogawa/theme-script:vite-plugin",
     transformIndexHtml() {


### PR DESCRIPTION
Just noticed this option is unused for vite plugin mode while adding it to
- https://github.com/hi-ogawa/argon2-wasm-bindgen/pull/9