### PR TITLE
feat(tiny-rpc): improve error serialization

### DIFF
--- a/.changeset/flat-colts-do.md
+++ b/.changeset/flat-colts-do.md
@@ -1,0 +1,5 @@
+---
+"@hiogawa/tiny-rpc": minor
+---
+
+feat: improve error propagation

--- a/packages/tiny-rpc/package.json
+++ b/packages/tiny-rpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/tiny-rpc",
-  "version": "0.2.3-pre.8",
+  "version": "0.2.3-pre.9",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/tiny-rpc/package.json
+++ b/packages/tiny-rpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/tiny-rpc",
-  "version": "0.2.3-pre.9",
+  "version": "0.2.3-pre.10",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/tiny-rpc/package.json
+++ b/packages/tiny-rpc/package.json
@@ -36,6 +36,7 @@
     "@hattip/adapter-node": "^0.0.34",
     "@hattip/compose": "^0.0.34",
     "@hiogawa/utils": "workspace:*",
+    "superjson": "^1.13.1",
     "zod": "^3.21.4"
   }
 }

--- a/packages/tiny-rpc/package.json
+++ b/packages/tiny-rpc/package.json
@@ -35,7 +35,7 @@
     "@brillout/json-serializer": "^0.5.4",
     "@hattip/adapter-node": "^0.0.34",
     "@hattip/compose": "^0.0.34",
-    "@hiogawa/json-extra": "^0.0.1",
+    "@hiogawa/json-extra": "workspace:*",
     "@hiogawa/utils": "workspace:*",
     "superjson": "^1.13.1",
     "zod": "^3.21.4"

--- a/packages/tiny-rpc/package.json
+++ b/packages/tiny-rpc/package.json
@@ -35,6 +35,7 @@
     "@brillout/json-serializer": "^0.5.4",
     "@hattip/adapter-node": "^0.0.34",
     "@hattip/compose": "^0.0.34",
+    "@hiogawa/json-extra": "^0.0.1",
     "@hiogawa/utils": "workspace:*",
     "superjson": "^1.13.1",
     "zod": "^3.21.4"

--- a/packages/tiny-rpc/src/adapter-http.test.ts
+++ b/packages/tiny-rpc/src/adapter-http.test.ts
@@ -105,6 +105,24 @@ describe("adapter-http", () => {
           }
         ]]
       `);
+      expect(e.cause).not.toBeInstanceOf(Error);
+      expect(e.cause).toBeInstanceOf(Object);
+      expect(e.cause).toMatchInlineSnapshot(`
+        {
+          "issues": [
+            {
+              "code": "invalid_type",
+              "expected": "number",
+              "message": "Expected number, received string",
+              "path": [
+                "delta",
+              ],
+              "received": "string",
+            },
+          ],
+          "name": "ZodError",
+        }
+      `);
       return true;
     });
 

--- a/packages/tiny-rpc/src/adapter-http.test.ts
+++ b/packages/tiny-rpc/src/adapter-http.test.ts
@@ -174,9 +174,7 @@ describe("adapter-http", () => {
     const routes = {
       identity: (v: any) => v,
 
-      validate: validateFn(z.date())(
-        (date) => new Date(date.getTime() + 1000 * 60 * 60)
-      ),
+      zodError: validateFn(z.number().int())((x) => 2 * x),
     } satisfies TinyRpcRoutes;
 
     //
@@ -221,10 +219,13 @@ describe("adapter-http", () => {
       regexp: /^\d+$/g,
     };
     expect(await client.identity(obj)).toEqual(obj);
-    expect(await client.validate(new Date("2023-08-17"))).toMatchInlineSnapshot(
-      "2023-08-17T01:00:00.000Z"
-    );
-    expect(await client.validate(new Date("2023-08-17"))).instanceOf(Date);
+    expect(await client.zodError(123)).toMatchInlineSnapshot("246");
+
+    // error
+    await expect(client.zodError(123.456)).rejects.toSatisfy((e) => {
+      expect(e).toMatchInlineSnapshot("[Error: Unexpected end of JSON input]");
+      return true;
+    });
   });
 });
 

--- a/packages/tiny-rpc/src/adapter-http.ts
+++ b/packages/tiny-rpc/src/adapter-http.ts
@@ -93,7 +93,7 @@ export function httpClientAdapter(opts: {
       const res = await fetch(req);
       const result: Result<unknown, unknown> = JSON.parse(await res.text());
       if (!result.ok) {
-        throw result.value;
+        throw TinyRpcError.fromUnknown(result.value);
       }
       return result.value;
     },

--- a/packages/tiny-rpc/src/adapter-http.ts
+++ b/packages/tiny-rpc/src/adapter-http.ts
@@ -105,6 +105,6 @@ const GET_PAYLOAD_PARAM = "payload";
 
 // do direct convertion `any <-> string` to support https://github.com/brillout/json-serializer
 interface JsonTransformer {
-  parse: (v: string) => any;
+  parse: (v: string) => any; // TODO: eliminate proto pollution at least on server by default cf. https://github.com/fastify/secure-json-parse
   stringify: (v: any) => string;
 }

--- a/packages/tiny-rpc/src/adapter-http.ts
+++ b/packages/tiny-rpc/src/adapter-http.ts
@@ -13,7 +13,7 @@ type RequestHandler = (ctx: {
 export function httpServerAdapter(opts: {
   endpoint: string;
   pathsForGET?: string[]; // GET is useful to cache reponse of public endpoint
-  JSON?: JsonTransformer;
+  JSON?: JsonTransformer; // it doesn't necessary have to be json string but we put "content-type: application/json" anyways for now
   onError?: (e: unknown) => void;
 }): TinyRpcServerAdapter<RequestHandler> {
   const JSON = opts.JSON ?? globalThis.JSON;

--- a/packages/tiny-rpc/src/adapter-http.ts
+++ b/packages/tiny-rpc/src/adapter-http.ts
@@ -46,6 +46,7 @@ export function httpServerAdapter(opts: {
         });
         let status = 200;
         if (!result.ok) {
+          // user can obfuscate server error via `onError` (e.g. purging e.stack = "")
           opts.onError?.(result.value);
           const e = TinyRpcError.fromUnknown(result.value);
           status = e.status;
@@ -93,7 +94,7 @@ export function httpClientAdapter(opts: {
       const res = await fetch(req);
       const result: Result<unknown, unknown> = JSON.parse(await res.text());
       if (!result.ok) {
-        throw TinyRpcError.fromUnknown(result.value);
+        throw TinyRpcError.deserialize(result.value);
       }
       return result.value;
     },

--- a/packages/tiny-rpc/src/adapter-message-port.test.ts
+++ b/packages/tiny-rpc/src/adapter-message-port.test.ts
@@ -66,6 +66,7 @@ describe("adapter-message-port", () => {
           }
         ]]
       `);
+      // TODO: support custom Error class in cause
       expect(e.cause).toBeInstanceOf(Error);
       expect(e.cause).not.toBeInstanceOf(TinyRpcError);
       expect(e.cause).toMatchInlineSnapshot("[Error]");

--- a/packages/tiny-rpc/src/adapter-message-port.test.ts
+++ b/packages/tiny-rpc/src/adapter-message-port.test.ts
@@ -66,6 +66,9 @@ describe("adapter-message-port", () => {
           }
         ]]
       `);
+      expect(e.cause).toBeInstanceOf(Error);
+      expect(e.cause).not.toBeInstanceOf(TinyRpcError);
+      expect(e.cause).toMatchInlineSnapshot("[Error]");
       return true;
     });
 

--- a/packages/tiny-rpc/src/adapter-message-port.ts
+++ b/packages/tiny-rpc/src/adapter-message-port.ts
@@ -83,7 +83,7 @@ export function messagePortClientAdapter({
       port.postMessage(req);
       const res = await promiseResolvers.promise;
       if (!res.result.ok) {
-        throw TinyRpcError.fromUnknown(res.result.value);
+        throw TinyRpcError.deserialize(res.result.value);
       }
       return res.result.value;
     },

--- a/packages/tiny-rpc/src/core.ts
+++ b/packages/tiny-rpc/src/core.ts
@@ -83,6 +83,7 @@ export class TinyRpcError extends Error {
   // TODO: allow obfuscating server error detail?
   serialize() {
     return {
+      name: "TinyRpcError",
       message: this.message,
       stack: this.stack,
       cause: this.cause,
@@ -94,19 +95,23 @@ export class TinyRpcError extends Error {
     if (e instanceof TinyRpcError) {
       return e;
     }
+    // cf. https://github.com/trpc/trpc/blob/fa7f6d6b804df71d8dd15970168f7be18aeecaf2/packages/server/src/error/TRPCError.ts#L53
     const err = new TinyRpcError("unknown", { cause: e });
     if (e && typeof e === "object") {
       if ("message" in e && typeof e.message === "string") {
         err.message = e.message;
       }
-      if ("stack" in e && typeof e.stack === "string") {
-        err.stack = e.stack;
-      }
-      if ("cause" in e) {
-        err.cause = e.cause;
-      }
-      if ("status" in e && typeof e.status === "number") {
-        err.status = e.status;
+      // copy others only when reviving serialized TinyRpcError
+      if ("name" in e && e.name === "TinyRpcError") {
+        if ("stack" in e && typeof e.stack === "string") {
+          err.stack = e.stack;
+        }
+        if ("cause" in e) {
+          err.cause = e.cause;
+        }
+        if ("status" in e && typeof e.status === "number") {
+          err.status = e.status;
+        }
       }
     }
     return err;

--- a/packages/tiny-rpc/src/core.ts
+++ b/packages/tiny-rpc/src/core.ts
@@ -72,7 +72,7 @@ export function proxyTinyRpc<R extends TinyRpcRoutes>({
 
 // cf. https://github.com/trpc/trpc/blob/fa7f6d6b804df71d8dd15970168f7be18aeecaf2/packages/server/src/error/TRPCError.ts#L53
 export class TinyRpcError extends Error {
-  // employ http status convention
+  // employ http status convention at the core level
   public status = 500;
 
   // convenient api for assertion

--- a/packages/tiny-rpc/src/core.ts
+++ b/packages/tiny-rpc/src/core.ts
@@ -1,4 +1,4 @@
-import { tinyassert } from "@hiogawa/utils";
+import { objectHas, tinyassert } from "@hiogawa/utils";
 
 //
 // TinyRpc routes schema
@@ -70,6 +70,7 @@ export function proxyTinyRpc<R extends TinyRpcRoutes>({
 // error
 //
 
+// cf. https://github.com/trpc/trpc/blob/fa7f6d6b804df71d8dd15970168f7be18aeecaf2/packages/server/src/error/TRPCError.ts#L53
 export class TinyRpcError extends Error {
   // employ http status convention
   public status = 500;
@@ -80,39 +81,30 @@ export class TinyRpcError extends Error {
     return this;
   }
 
-  // TODO: allow obfuscating server error detail?
   serialize() {
     return {
-      name: "TinyRpcError",
       message: this.message,
-      stack: this.stack,
-      cause: this.cause,
+      stack: this.stack ?? "",
+      cause: this.cause ?? null,
       status: this.status,
     };
+  }
+
+  static deserialize(e: unknown): TinyRpcError {
+    tinyassert(objectHas(e, "message") && typeof e.message === "string");
+    tinyassert(objectHas(e, "stack") && typeof e.stack === "string");
+    tinyassert(objectHas(e, "cause"));
+    tinyassert(objectHas(e, "status") && typeof e.status === "number");
+    return Object.assign(new TinyRpcError(), e);
   }
 
   static fromUnknown(e: unknown): TinyRpcError {
     if (e instanceof TinyRpcError) {
       return e;
     }
-    // cf. https://github.com/trpc/trpc/blob/fa7f6d6b804df71d8dd15970168f7be18aeecaf2/packages/server/src/error/TRPCError.ts#L53
     const err = new TinyRpcError("unknown", { cause: e });
-    if (e && typeof e === "object") {
-      if ("message" in e && typeof e.message === "string") {
-        err.message = e.message;
-      }
-      // copy others only when reviving serialized TinyRpcError
-      if ("name" in e && e.name === "TinyRpcError") {
-        if ("stack" in e && typeof e.stack === "string") {
-          err.stack = e.stack;
-        }
-        if ("cause" in e) {
-          err.cause = e.cause;
-        }
-        if ("status" in e && typeof e.status === "number") {
-          err.status = e.status;
-        }
-      }
+    if (objectHas(e, "message") && typeof e.message === "string") {
+      err.message = e.message;
     }
     return err;
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,6 +137,9 @@ importers:
       '@hiogawa/utils':
         specifier: workspace:*
         version: link:../utils
+      superjson:
+        specifier: ^1.13.1
+        version: 1.13.1
       zod:
         specifier: ^3.21.4
         version: 3.21.4
@@ -2380,6 +2383,13 @@ packages:
     resolution: {integrity: sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==}
     dev: true
 
+  /copy-anything@3.0.5:
+    resolution: {integrity: sha512-yCEafptTtb4bk7GLEQoM8KVJpxAfdBJYaXyzQEgQQQgYrZiDp8SJmGKlYza6CYjEDNstAdNdKA3UuoULlEbS6w==}
+    engines: {node: '>=12.13'}
+    dependencies:
+      is-what: 4.1.15
+    dev: true
+
   /cross-spawn@5.1.0:
     resolution: {integrity: sha512-pTgQJ5KC0d2hcY8eyL1IzlBPYjTkyH72XRZPnLyKus2mBfNjQs3klqbJU2VILqZryAZUt9JOb3h/mWMy23/f5A==}
     dependencies:
@@ -3466,6 +3476,11 @@ packages:
     dependencies:
       call-bind: 1.0.2
       get-intrinsic: 1.2.1
+    dev: true
+
+  /is-what@4.1.15:
+    resolution: {integrity: sha512-uKua1wfy3Yt+YqsD6mTUEa2zSi3G1oPlqTflgaPJ7z63vUGN5pxFpnQfeSLMFnJDEsdvOtkp1rUWkYjB4YfhgA==}
+    engines: {node: '>=12.13'}
     dev: true
 
   /is-windows@1.0.2:
@@ -4851,6 +4866,13 @@ packages:
       mz: 2.7.0
       pirates: 4.0.6
       ts-interface-checker: 0.1.13
+    dev: true
+
+  /superjson@1.13.1:
+    resolution: {integrity: sha512-AVH2eknm9DEd3qvxM4Sq+LTCkSXE2ssfh1t11MHMXyYXFQyQ1HLgVvV+guLTsaQnJU3gnaVo34TohHPulY/wLg==}
+    engines: {node: '>=10'}
+    dependencies:
+      copy-anything: 3.0.5
     dev: true
 
   /supports-color@5.5.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,6 +134,9 @@ importers:
       '@hattip/compose':
         specifier: ^0.0.34
         version: 0.0.34
+      '@hiogawa/json-extra':
+        specifier: ^0.0.1
+        version: 0.0.1
       '@hiogawa/utils':
         specifier: workspace:*
         version: link:../utils
@@ -1302,6 +1305,10 @@ packages:
     dependencies:
       prettier: 2.8.8
       typescript: 5.1.6
+    dev: true
+
+  /@hiogawa/json-extra@0.0.1:
+    resolution: {integrity: sha512-LFh/FLhj0s0LqxCeHPD6xk8j+01oSkqKOwTH2+lQtxbMW6b7Br6TynMlTQ9RUT9d3Ih4+IcqNeopudwRUMnuvQ==}
     dev: true
 
   /@hiogawa/unocss-preset-antd@2.2.1-pre.3(@unocss/preset-uno@0.54.0)(unocss@0.53.6):

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,8 +153,8 @@ importers:
         specifier: ^0.0.34
         version: 0.0.34
       '@hiogawa/json-extra':
-        specifier: ^0.0.1
-        version: 0.0.1
+        specifier: workspace:*
+        version: link:../json-extra
       '@hiogawa/utils':
         specifier: workspace:*
         version: link:../utils
@@ -1323,10 +1323,6 @@ packages:
     dependencies:
       prettier: 2.8.8
       typescript: 5.1.6
-    dev: true
-
-  /@hiogawa/json-extra@0.0.1:
-    resolution: {integrity: sha512-LFh/FLhj0s0LqxCeHPD6xk8j+01oSkqKOwTH2+lQtxbMW6b7Br6TynMlTQ9RUT9d3Ih4+IcqNeopudwRUMnuvQ==}
     dev: true
 
   /@hiogawa/unocss-preset-antd@2.2.1-pre.3(@unocss/preset-uno@0.54.0)(unocss@0.53.6):


### PR DESCRIPTION
- cf. https://github.com/hi-ogawa/ytsub-v3/pull/473

While doing https://github.com/hi-ogawa/ytsub-v3/pull/473, I noticed that custom error e.g. `ZodError` is not properly propagated when using custom serializer.
For example, `json-serializer` throws and `superjson` is also not keeping `ZodError.issues` (though that's same when trpc).
Actual serialization must be taken care by custom json serializer, but current `TinyRpcError` internal handling also requires to be adjusted, which is what this PR does.