### PR TITLE
feat: add `utils-node` package with zx-like script helper

### DIFF
--- a/misc/generate-tsconfig.mjs
+++ b/misc/generate-tsconfig.mjs
@@ -1,0 +1,16 @@
+import process from "node:process";
+import { $ } from "@hiogawa/utils-node";
+
+// usage:
+//   node misc/generate-tsconfig.mjs > tsconfig.json
+
+const pnpmList = JSON.parse(
+  await $`pnpm ls --filter './packages/**' --depth -1 --json`
+);
+const cwdLen = process.cwd().length;
+const paths = pnpmList.map((e) => e.path.slice(cwdLen + 1));
+const tsconfig = {
+  include: [],
+  references: paths.map((path) => ({ path })),
+};
+console.log(JSON.stringify(tsconfig, null, 2));

--- a/misc/generate-tsconfig.mjs
+++ b/misc/generate-tsconfig.mjs
@@ -4,6 +4,8 @@ import { $ } from "@hiogawa/utils-node";
 // usage:
 //   node misc/generate-tsconfig.mjs > tsconfig.json
 
+$._.verbose = true;
+
 const pnpmList = JSON.parse(
   await $`pnpm ls --filter './packages/**' --depth -1 --json`
 );

--- a/misc/generate-tsconfig.sh
+++ b/misc/generate-tsconfig.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-set -eu -o pipefail
-
-# usage
-#   bash misc/generate-tsconfig.sh > tsconfig.json
-
-pnpm ls --filter './packages/**' --depth -1 --json \
-  | jq -r --argjson PWD_LEN "${#PWD}" '{ include: [], references: map({ path: .path[$PWD_LEN + 1:] }) }'

--- a/misc/pre-release.mjs
+++ b/misc/pre-release.mjs
@@ -6,6 +6,8 @@ import fs from "node:fs";
 // usage:
 //   node misc/pre-release.mjs packages/utils-node
 
+$._.verbose = true;
+
 async function main() {
   const packageDir = process.argv[2];
   tinyassert(packageDir, "missing 'packageDir'");
@@ -14,7 +16,7 @@ async function main() {
   // require no diff to start
   const gitStatus = await $`git status --porcelain`;
   if (gitStatus) {
-    console.error("dirty 'git status'");
+    console.error("[ERROR] require clean 'git status'");
     console.error(gitStatus);
     process.exit(1);
   }

--- a/misc/pre-release.mjs
+++ b/misc/pre-release.mjs
@@ -1,0 +1,42 @@
+import process from "node:process";
+import { tinyassert } from "@hiogawa/utils";
+import { $ } from "@hiogawa/utils-node";
+import fs from "node:fs";
+
+// usage:
+//   node misc/pre-release.mjs packages/utils-node
+
+async function main() {
+  const packageDir = process.argv[2];
+  tinyassert(packageDir, "missing 'packageDir'");
+
+  // require no diff to start
+  await $`git diff --exit-code --name-only`;
+
+  // update version
+  /** @type {{ version: string }} */
+  const pakcageJson = JSON.parse(
+    fs.readFileSync(`${packageDir}/package.json`, "utf-8")
+  );
+  pakcageJson.version = getNextVersion(pakcageJson.version);
+  fs.writeFileSync(
+    `${packageDir}/package.json`,
+    JSON.stringify(pakcageJson, null, 2) + "\n"
+  );
+}
+
+/**
+ * @param {string} version
+ */
+function getNextVersion(version) {
+  const vs = version.match(/(\d+).(\d+).(\d+)(?:-pre.(\d+))?/).slice(1);
+  if (vs[3]) {
+    vs[3] = Number(vs[3]) + 1;
+  } else {
+    vs[2] = Number(vs[2]) + 1;
+    vs[3] = 0;
+  }
+  return vs.slice(0, -1).join(".") + "-pre." + vs[3];
+}
+
+main();

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "devDependencies": {
     "@changesets/cli": "^2.26.2",
     "@hiogawa/isort-ts": "1.1.1",
+    "@hiogawa/utils-node": "workspace:*",
     "@tsconfig/strictest": "^2.0.1",
     "esbuild": "^0.18.10",
     "npm-run-all": "^4.1.5",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "devDependencies": {
     "@changesets/cli": "^2.26.2",
     "@hiogawa/isort-ts": "1.1.1",
+    "@hiogawa/utils": "workspace:*",
     "@hiogawa/utils-node": "workspace:*",
     "@tsconfig/strictest": "^2.0.1",
     "esbuild": "^0.18.10",

--- a/packages/utils-node/README.md
+++ b/packages/utils-node/README.md
@@ -1,0 +1,1 @@
+# utils-node

--- a/packages/utils-node/package.json
+++ b/packages/utils-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/utils-node",
-  "version": "0.0.1-pre.1",
+  "version": "0.0.1-pre.2",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/utils-node/package.json
+++ b/packages/utils-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/utils-node",
-  "version": "0.0.1-pre.0",
+  "version": "0.0.1-pre.1",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/utils-node/package.json
+++ b/packages/utils-node/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@hiogawa/utils-node",
+  "version": "0.0.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/hi-ogawa/js-utils",
+    "directory": "packages/utils-node"
+  },
+  "scripts": {
+    "build": "tsup",
+    "test": "vitest",
+    "release": "pnpm publish --no-git-checks --access public"
+  },
+  "devDependencies": {
+    "@hiogawa/utils": "workspace:*",
+    "@types/node": "^20.5.6"
+  }
+}

--- a/packages/utils-node/package.json
+++ b/packages/utils-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/utils-node",
-  "version": "0.0.1-pre.2",
+  "version": "0.0.1-pre.3",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/utils-node/package.json
+++ b/packages/utils-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/utils-node",
-  "version": "0.0.0",
+  "version": "0.0.1-pre.0",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/utils-node/src/index.ts
+++ b/packages/utils-node/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./script";

--- a/packages/utils-node/src/script.test.ts
+++ b/packages/utils-node/src/script.test.ts
@@ -37,7 +37,7 @@ describe($new, () => {
       expect(result).toMatchInlineSnapshot(`
         {
           "ok": false,
-          "value": [Error: ChildProcess error],
+          "value": [Error: ScriptError],
         }
       `);
       tinyassert(!result.ok);

--- a/packages/utils-node/src/script.test.ts
+++ b/packages/utils-node/src/script.test.ts
@@ -13,7 +13,7 @@ describe("script", () => {
     const $ = $new();
     $._.noTrim = true;
     $._.verbose = true;
-    $._.log = (v) => logFn(v.replace(/^\[.*?\]/, "[...]")); // reduct non-deterministic timestamp
+    $._.log = (v) => logFn(v.replace(/^\[\d{2}:\d{2}:\d{2}.\d{3}\]/, "[...]")); // reduct non-deterministic timestamp
     const output = await $`echo ${"hello"} ${"world"}`;
     expect(output).toMatchInlineSnapshot(`
       "hello world

--- a/packages/utils-node/src/script.test.ts
+++ b/packages/utils-node/src/script.test.ts
@@ -1,3 +1,4 @@
+import { tinyassert, wrapErrorAsync } from "@hiogawa/utils";
 import { describe, expect, it, vi } from "vitest";
 import { $, newScriptHelper } from "./script";
 
@@ -28,5 +29,27 @@ describe(newScriptHelper, () => {
         ],
       ]
     `);
+  });
+
+  describe("error", () => {
+    it("command status", async () => {
+      const result = await wrapErrorAsync(async () => await $`node --yelp`);
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "ok": false,
+          "value": [Error: ChildProcess error],
+        }
+      `);
+      tinyassert(!result.ok);
+      tinyassert(result.value instanceof Error);
+      expect(result.value.cause).toMatchInlineSnapshot(`
+        {
+          "code": 9,
+          "stderr": "",
+          "stdout": "node: bad option: --yelp
+        ",
+        }
+      `);
+    });
   });
 });

--- a/packages/utils-node/src/script.test.ts
+++ b/packages/utils-node/src/script.test.ts
@@ -11,7 +11,7 @@ describe("script", () => {
   it("helperOptions", async () => {
     const logFn = vi.fn();
     const $ = $new({
-      $: {
+      _: {
         noTrim: true,
         verbose: true,
         log: logFn,

--- a/packages/utils-node/src/script.test.ts
+++ b/packages/utils-node/src/script.test.ts
@@ -13,7 +13,7 @@ describe("script", () => {
     const $ = $new();
     $._.noTrim = true;
     $._.verbose = true;
-    $._.log = logFn;
+    $._.log = (v) => logFn(v.replace(/^\[.*?\]/, "[...]")); // reduct non-deterministic timestamp
     const output = await $`echo ${"hello"} ${"world"}`;
     expect(output).toMatchInlineSnapshot(`
       "hello world
@@ -22,7 +22,7 @@ describe("script", () => {
     expect(logFn.mock.calls).toMatchInlineSnapshot(`
       [
         [
-          "$ echo hello world",
+          "[...] echo hello world",
         ],
       ]
     `);

--- a/packages/utils-node/src/script.test.ts
+++ b/packages/utils-node/src/script.test.ts
@@ -3,8 +3,8 @@ import { $, newScriptHelper } from "./script";
 
 describe(newScriptHelper, () => {
   it("basic", async () => {
-    const output = await $`echo hello`;
-    expect(output).toMatchInlineSnapshot('"hello"');
+    const output = await $`echo ${"hello"} ${"world"}`;
+    expect(output).toMatchInlineSnapshot('"hello world"');
   });
 
   it("helperOptions", async () => {
@@ -16,15 +16,15 @@ describe(newScriptHelper, () => {
         consoleLog: logFn,
       },
     });
-    const output = await $`echo hello`;
+    const output = await $`echo ${"hello"} ${"world"}`;
     expect(output).toMatchInlineSnapshot(`
-      "hello
+      "hello world
       "
     `);
     expect(logFn.mock.calls).toMatchInlineSnapshot(`
       [
         [
-          "$ echo hello",
+          "$ echo hello world",
         ],
       ]
     `);

--- a/packages/utils-node/src/script.test.ts
+++ b/packages/utils-node/src/script.test.ts
@@ -10,7 +10,11 @@ describe(newScriptHelper, () => {
   it("helperOptions", async () => {
     const logFn = vi.fn();
     const $ = newScriptHelper({
-      helper: { noTrim: true, verbose: true, log: logFn },
+      $: {
+        noTrim: true,
+        verbose: true,
+        consoleLog: logFn,
+      },
     });
     const output = await $`echo hello`;
     expect(output).toMatchInlineSnapshot(`

--- a/packages/utils-node/src/script.test.ts
+++ b/packages/utils-node/src/script.test.ts
@@ -10,13 +10,10 @@ describe("script", () => {
 
   it("helperOptions", async () => {
     const logFn = vi.fn();
-    const $ = $new({
-      _: {
-        noTrim: true,
-        verbose: true,
-        log: logFn,
-      },
-    });
+    const $ = $new();
+    $._.noTrim = true;
+    $._.verbose = true;
+    $._.log = logFn;
     const output = await $`echo ${"hello"} ${"world"}`;
     expect(output).toMatchInlineSnapshot(`
       "hello world

--- a/packages/utils-node/src/script.test.ts
+++ b/packages/utils-node/src/script.test.ts
@@ -46,11 +46,25 @@ describe($new, () => {
         {
           "code": 9,
           "command": "node --yelp",
-          "stderr": "",
-          "stdout": "node: bad option: --yelp
+          "stderr": "node: bad option: --yelp
         ",
+          "stdout": "",
         }
       `);
     });
+  });
+
+  it("ChildProcess", async () => {
+    const spawned = $`node -e 'console.log("abc"); console.error("def")'`;
+    expect(await spawned.promise).toMatchInlineSnapshot('"abc"');
+    expect(spawned.stdout).toMatchInlineSnapshot(`
+      "abc
+      "
+    `);
+    expect(spawned.stderr).toMatchInlineSnapshot(`
+      "def
+      "
+    `);
+    expect(spawned.child.exitCode).toMatchInlineSnapshot("0");
   });
 });

--- a/packages/utils-node/src/script.test.ts
+++ b/packages/utils-node/src/script.test.ts
@@ -2,7 +2,7 @@ import { tinyassert, wrapErrorAsync } from "@hiogawa/utils";
 import { describe, expect, it, vi } from "vitest";
 import { $, $new } from "./script";
 
-describe($new, () => {
+describe("script", () => {
   it("basic", async () => {
     const output = await $`echo ${"hello"} ${"world"}`;
     expect(output).toMatchInlineSnapshot('"hello world"');

--- a/packages/utils-node/src/script.test.ts
+++ b/packages/utils-node/src/script.test.ts
@@ -1,8 +1,8 @@
 import { tinyassert, wrapErrorAsync } from "@hiogawa/utils";
 import { describe, expect, it, vi } from "vitest";
-import { $, newScriptHelper } from "./script";
+import { $, $new } from "./script";
 
-describe(newScriptHelper, () => {
+describe($new, () => {
   it("basic", async () => {
     const output = await $`echo ${"hello"} ${"world"}`;
     expect(output).toMatchInlineSnapshot('"hello world"');
@@ -10,7 +10,7 @@ describe(newScriptHelper, () => {
 
   it("helperOptions", async () => {
     const logFn = vi.fn();
-    const $ = newScriptHelper({
+    const $ = $new({
       $: {
         noTrim: true,
         verbose: true,

--- a/packages/utils-node/src/script.test.ts
+++ b/packages/utils-node/src/script.test.ts
@@ -14,7 +14,7 @@ describe("script", () => {
       $: {
         noTrim: true,
         verbose: true,
-        consoleLog: logFn,
+        log: logFn,
       },
     });
     const output = await $`echo ${"hello"} ${"world"}`;
@@ -54,17 +54,26 @@ describe("script", () => {
     });
   });
 
-  it("ChildProcess", async () => {
-    const spawned = $`node -e 'console.log("abc"); console.error("def")'`;
-    expect(await spawned.promise).toMatchInlineSnapshot('"abc"');
-    expect(spawned.stdout).toMatchInlineSnapshot(`
-      "abc
-      "
-    `);
-    expect(spawned.stderr).toMatchInlineSnapshot(`
-      "def
-      "
-    `);
-    expect(spawned.child.exitCode).toMatchInlineSnapshot("0");
+  describe("ChildProcess", () => {
+    it("basic", async () => {
+      const proc = $`node -e 'console.log("abc"); console.error("def")'`;
+      expect(await proc.promise).toMatchInlineSnapshot('"abc"');
+      expect(proc.stdout).toMatchInlineSnapshot(`
+        "abc
+        "
+      `);
+      expect(proc.stderr).toMatchInlineSnapshot(`
+        "def
+        "
+      `);
+      expect(proc.child.exitCode).toMatchInlineSnapshot("0");
+    });
+
+    it("stdin", async () => {
+      const proc = $`node -`;
+      tinyassert(proc.child.stdin);
+      proc.child.stdin.end("console.log(1 + 1)");
+      expect(await proc.promise).toMatchInlineSnapshot('"2"');
+    });
   });
 });

--- a/packages/utils-node/src/script.test.ts
+++ b/packages/utils-node/src/script.test.ts
@@ -45,6 +45,7 @@ describe($new, () => {
       expect(result.value.cause).toMatchInlineSnapshot(`
         {
           "code": 9,
+          "command": "node --yelp",
           "stderr": "",
           "stdout": "node: bad option: --yelp
         ",

--- a/packages/utils-node/src/script.test.ts
+++ b/packages/utils-node/src/script.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from "vitest";
+import { $, newScriptHelper } from "./script";
+
+describe(newScriptHelper, () => {
+  it("basic", async () => {
+    const output = await $`echo hello`;
+    expect(output).toMatchInlineSnapshot('"hello"');
+  });
+
+  it("helperOptions", async () => {
+    const logFn = vi.fn();
+    const $ = newScriptHelper({
+      helper: { noTrim: true, verbose: true, log: logFn },
+    });
+    const output = await $`echo hello`;
+    expect(output).toMatchInlineSnapshot(`
+      "hello
+      "
+    `);
+    expect(logFn.mock.calls).toMatchInlineSnapshot(`
+      [
+        [
+          "$ echo hello",
+        ],
+      ]
+    `);
+  });
+});

--- a/packages/utils-node/src/script.ts
+++ b/packages/utils-node/src/script.ts
@@ -31,13 +31,15 @@ export function newScriptHelper(options: {
   const spawnOptions = { ...defaultSpawnOptions, ...options.spawn };
   const helperOptions = options.helper ?? {};
 
-  return function $(strings: TemplateStringsArray, ...params: ScriptParam[]) {
+  function $(strings: TemplateStringsArray, ...params: ScriptParam[]) {
     const command = [zip(strings, params), strings.at(-1)].flat(2).join("");
     if (helperOptions.verbose) {
       console.log("$ ", command);
     }
     return new SpawnPromise(command, spawnOptions, helperOptions);
-  };
+  }
+
+  return $;
 }
 
 class SpawnPromise implements PromiseLike<string> {

--- a/packages/utils-node/src/script.ts
+++ b/packages/utils-node/src/script.ts
@@ -9,6 +9,7 @@ import {
 // https://github.com/google/zx
 // https://github.com/sindresorhus/execa/blob/f4b8b3ab601c94d1503f1010822952758dcc6350/docs/scripts.md
 
+// TODO: support array and unescaped wrapper?
 type ScriptParam = string | number;
 
 const defaultSpawnOptions: SpawnOptions = {
@@ -16,6 +17,9 @@ const defaultSpawnOptions: SpawnOptions = {
   stdio: ["ignore", "pipe", "pipe"],
 };
 
+// TODO
+// abstract command escape/parsing and spawn implementation?
+// e.g. for https://github.com/moxystudio/node-cross-spawn
 type HelperOptions = {
   noTrim?: boolean;
   verbose?: boolean;

--- a/packages/utils-node/src/script.ts
+++ b/packages/utils-node/src/script.ts
@@ -9,7 +9,6 @@ import {
 // https://github.com/google/zx
 // https://github.com/sindresorhus/execa/blob/f4b8b3ab601c94d1503f1010822952758dcc6350/docs/scripts.md
 
-// TODO: support array and unescaped wrapper?
 type ScriptParam = string | number;
 
 const defaultSpawnOptions: SpawnOptions = {
@@ -34,9 +33,9 @@ export function $new(options: SpawnOptions & { $?: HelperOptions } = {}) {
 
   return function $(strings: TemplateStringsArray, ...params: ScriptParam[]) {
     let command = strings[0];
-    for (let i = 0; i < params.length; i++) {
-      command += params[i] + strings[i + 1];
-    }
+    params.forEach((param, i) => {
+      command += param + strings[i + 1];
+    });
     if (helperOptions.verbose) {
       log(`$ ${command}`);
     }

--- a/packages/utils-node/src/script.ts
+++ b/packages/utils-node/src/script.ts
@@ -78,7 +78,7 @@ class SpawnPromise implements PromiseLike<string> {
           resolve(stdout);
         } else {
           reject(
-            new Error(`ChildProcess error`, {
+            new Error(`ScriptError`, {
               cause: {
                 code,
                 stdout: this.stdout,

--- a/packages/utils-node/src/script.ts
+++ b/packages/utils-node/src/script.ts
@@ -16,13 +16,11 @@ const defaultSpawnOptions: SpawnOptions = {
   stdio: ["pipe", "pipe", "pipe"],
 };
 
-// TODO
-// abstract command escape/parsing and spawn implementation?
-// e.g. for https://github.com/moxystudio/node-cross-spawn
 type HelperOptions = {
   noTrim?: boolean;
   verbose?: boolean;
   log?: (v: string) => void;
+  spawn?: typeof import("node:child_process").spawn; // it could be for https://github.com/moxystudio/node-cross-spawn
 };
 
 export const $ = /* @__PURE__ */ $new();
@@ -58,7 +56,8 @@ class SpawnPromise implements PromiseLike<string> {
     private options: SpawnOptions,
     private helperOptions: HelperOptions
   ) {
-    const child = spawn(this.command, this.options);
+    const spawnImpl = helperOptions.spawn ?? spawn;
+    const child = spawnImpl(this.command, this.options);
     this.child = child;
     this.promise = new Promise<string>((resolve, reject) => {
       child.stdout?.on("data", (raw: unknown) => {

--- a/packages/utils-node/src/script.ts
+++ b/packages/utils-node/src/script.ts
@@ -14,7 +14,7 @@ type ScriptParam = string | number;
 
 const defaultSpawnOptions: SpawnOptions = {
   shell: true,
-  stdio: ["ignore", "pipe", "pipe"],
+  stdio: ["pipe", "pipe", "pipe"],
 };
 
 // TODO
@@ -23,14 +23,14 @@ const defaultSpawnOptions: SpawnOptions = {
 type HelperOptions = {
   noTrim?: boolean;
   verbose?: boolean;
-  consoleLog?: (v: string) => void;
+  log?: (v: string) => void;
 };
 
 export const $ = /* @__PURE__ */ $new();
 
 export function $new(options: SpawnOptions & { $?: HelperOptions } = {}) {
   const { $: helperOptions = {}, ...spawnOptions } = options;
-  const log = helperOptions.consoleLog ?? console.log;
+  const log = helperOptions.log ?? console.error;
 
   return function $(strings: TemplateStringsArray, ...params: ScriptParam[]) {
     let command = strings[0];
@@ -62,9 +62,6 @@ class SpawnPromise implements PromiseLike<string> {
     const child = spawn(this.command, this.options);
     this.child = child;
     this.promise = new Promise<string>((resolve, reject) => {
-      // TODO: support stdin?
-      child.stdin;
-
       child.stdout?.on("data", (raw: unknown) => {
         processOutput(raw, (v) => (this.stdout += v), reject);
       });

--- a/packages/utils-node/src/script.ts
+++ b/packages/utils-node/src/script.ts
@@ -4,7 +4,6 @@ import {
   type SpawnOptions,
   spawn,
 } from "node:child_process";
-import { zip } from "@hiogawa/utils";
 
 // too simple but maybe useful enough version of
 // https://github.com/google/zx
@@ -32,7 +31,10 @@ export function newScriptHelper(
   const log = helperOptions.consoleLog ?? console.log;
 
   return function $(strings: TemplateStringsArray, ...params: ScriptParam[]) {
-    const command = [zip(strings, params), strings.at(-1)].flat(2).join("");
+    let command = strings[0];
+    for (let i = 0; i < params.length; i++) {
+      command += params[i] + strings[i + 1];
+    }
     if (helperOptions.verbose) {
       log(`$ ${command}`);
     }

--- a/packages/utils-node/src/script.ts
+++ b/packages/utils-node/src/script.ts
@@ -80,6 +80,7 @@ class SpawnPromise implements PromiseLike<string> {
           reject(
             new Error(`ScriptError`, {
               cause: {
+                command,
                 code,
                 stdout: this.stdout,
                 stderr: this.stderr,

--- a/packages/utils-node/src/script.ts
+++ b/packages/utils-node/src/script.ts
@@ -1,0 +1,101 @@
+import { Buffer } from "node:buffer";
+import {
+  type ChildProcess,
+  type SpawnOptions,
+  spawn,
+} from "node:child_process";
+import { zip } from "@hiogawa/utils";
+
+// too simple but maybe useful enough version of
+// https://github.com/google/zx
+// https://github.com/sindresorhus/execa/blob/f4b8b3ab601c94d1503f1010822952758dcc6350/docs/scripts.md
+
+type ScriptParam = string | number;
+
+type HelperOptions = {
+  noTrim?: boolean;
+  verbose?: boolean;
+};
+
+const defaultSpawnOptions: SpawnOptions = {
+  shell: true,
+  stdio: ["ignore", "pipe", "pipe"],
+};
+
+export const $ = /* @__PURE__ */ newScriptHelper({});
+
+export function newScriptHelper(options: {
+  spawn?: SpawnOptions;
+  helper?: HelperOptions;
+}) {
+  const spawnOptions = { ...defaultSpawnOptions, ...options.spawn };
+  const helperOptions = options.helper ?? {};
+
+  return function $(strings: TemplateStringsArray, ...params: ScriptParam[]) {
+    const command = [zip(strings, params), strings.at(-1)].flat(2).join("");
+    if (helperOptions.verbose) {
+      console.log("$ ", command);
+    }
+    return new SpawnPromise(command, spawnOptions, helperOptions);
+  };
+}
+
+class SpawnPromise implements PromiseLike<string> {
+  child: ChildProcess;
+  promise: Promise<string>;
+  stderr: string = "";
+  stdout: string = "";
+
+  constructor(
+    private command: string,
+    private options: SpawnOptions,
+    private helperOptions: HelperOptions
+  ) {
+    const child = spawn(this.command, this.options);
+    this.child = child;
+    this.promise = new Promise<string>((resolve, reject) => {
+      // TODO: support stdin?
+      child.stdin;
+
+      child.stdout?.on("data", (raw: unknown) => {
+        processOutput(raw, (v) => (this.stdout += v), reject);
+      });
+
+      child.stderr?.on("data", (raw: unknown) => {
+        processOutput(raw, (v) => (this.stdout += v), reject);
+      });
+
+      child.on("close", (code) => {
+        if (code === 0) {
+          let stdout = this.stdout;
+          if (!this.helperOptions.noTrim) {
+            stdout = stdout.trim();
+          }
+          resolve(this.stdout.trim());
+        } else {
+          reject(new Error(`ChildProcess code ${code}`));
+        }
+      });
+
+      child.on("error", (err) => {
+        reject(err);
+      });
+    });
+  }
+
+  // delegate promise api
+  then: PromiseLike<string>["then"] = (...args) => this.promise.then(...args);
+}
+
+function processOutput(
+  raw: unknown,
+  onSuccess: (v: string) => void,
+  onError: (v: unknown) => void
+) {
+  if (typeof raw === "string") {
+    return onSuccess(raw);
+  } else if (raw instanceof Buffer) {
+    return onSuccess(raw.toString());
+  }
+  onError(new Error("unknown data", { cause: raw }));
+}

--- a/packages/utils-node/src/script.ts
+++ b/packages/utils-node/src/script.ts
@@ -66,7 +66,7 @@ class SpawnPromise implements PromiseLike<string> {
       });
 
       child.stderr?.on("data", (raw: unknown) => {
-        processOutput(raw, (v) => (this.stdout += v), reject);
+        processOutput(raw, (v) => (this.stderr += v), reject);
       });
 
       child.on("close", (code) => {

--- a/packages/utils-node/src/script.ts
+++ b/packages/utils-node/src/script.ts
@@ -22,11 +22,9 @@ type HelperOptions = {
   consoleLog?: (v: string) => void;
 };
 
-export const $ = /* @__PURE__ */ newScriptHelper();
+export const $ = /* @__PURE__ */ $new();
 
-export function newScriptHelper(
-  options: SpawnOptions & { $?: HelperOptions } = {}
-) {
+export function $new(options: SpawnOptions & { $?: HelperOptions } = {}) {
   const { $: helperOptions = {}, ...spawnOptions } = options;
   const log = helperOptions.consoleLog ?? console.log;
 

--- a/packages/utils-node/src/script.ts
+++ b/packages/utils-node/src/script.ts
@@ -58,19 +58,6 @@ export function $new(
   return api;
 }
 
-function formatNow() {
-  // cf. https://github.com/sindresorhus/execa/blob/f4b8b3ab601c94d1503f1010822952758dcc6350/lib/verbose.js#L10
-  const d = new Date();
-  const h = d.getHours();
-  const m = d.getMinutes();
-  const s = d.getSeconds();
-  const ms = d.getMilliseconds();
-  function pad(n: number, max: number) {
-    return String(n).padStart(max, "0");
-  }
-  return `${pad(h, 2)}:${pad(m, 2)}:${pad(s, 2)}.${pad(ms, 3)}`;
-}
-
 class SpawnPromiseLike implements PromiseLike<string> {
   child: ChildProcess;
   promise: Promise<string>;
@@ -135,4 +122,17 @@ function processOutput(
     return onSuccess(raw.toString());
   }
   onError(new Error("unknown data", { cause: raw }));
+}
+
+function formatNow() {
+  // cf. https://github.com/sindresorhus/execa/blob/f4b8b3ab601c94d1503f1010822952758dcc6350/lib/verbose.js#L10
+  const d = new Date();
+  const h = d.getHours();
+  const m = d.getMinutes();
+  const s = d.getSeconds();
+  const ms = d.getMilliseconds();
+  function pad(n: number, max: number) {
+    return String(n).padStart(max, "0");
+  }
+  return `${pad(h, 2)}:${pad(m, 2)}:${pad(s, 2)}.${pad(ms, 3)}`;
 }

--- a/packages/utils-node/src/script.ts
+++ b/packages/utils-node/src/script.ts
@@ -15,6 +15,7 @@ type ScriptParam = string | number;
 type HelperOptions = {
   noTrim?: boolean;
   verbose?: boolean;
+  log?: (v: string) => void;
 };
 
 const defaultSpawnOptions: SpawnOptions = {
@@ -22,19 +23,20 @@ const defaultSpawnOptions: SpawnOptions = {
   stdio: ["ignore", "pipe", "pipe"],
 };
 
-export const $ = /* @__PURE__ */ newScriptHelper({});
+export const $ = /* @__PURE__ */ newScriptHelper();
 
-export function newScriptHelper(options: {
+export function newScriptHelper(options?: {
   spawn?: SpawnOptions;
   helper?: HelperOptions;
 }) {
-  const spawnOptions = { ...defaultSpawnOptions, ...options.spawn };
-  const helperOptions = options.helper ?? {};
+  const spawnOptions = { ...defaultSpawnOptions, ...options?.spawn };
+  const helperOptions = options?.helper ?? {};
+  const log = helperOptions.log ?? console.log;
 
   function $(strings: TemplateStringsArray, ...params: ScriptParam[]) {
     const command = [zip(strings, params), strings.at(-1)].flat(2).join("");
     if (helperOptions.verbose) {
-      console.log("$ ", command);
+      log(`$ ${command}`);
     }
     return new SpawnPromise(command, spawnOptions, helperOptions);
   }
@@ -73,7 +75,7 @@ class SpawnPromise implements PromiseLike<string> {
           if (!this.helperOptions.noTrim) {
             stdout = stdout.trim();
           }
-          resolve(this.stdout.trim());
+          resolve(stdout);
         } else {
           reject(new Error(`ChildProcess code ${code}`));
         }

--- a/packages/utils-node/src/script.ts
+++ b/packages/utils-node/src/script.ts
@@ -125,14 +125,11 @@ function processOutput(
 }
 
 function formatNow() {
-  // cf. https://github.com/sindresorhus/execa/blob/f4b8b3ab601c94d1503f1010822952758dcc6350/lib/verbose.js#L10
-  const d = new Date();
-  const h = d.getHours();
-  const m = d.getMinutes();
-  const s = d.getSeconds();
-  const ms = d.getMilliseconds();
-  function pad(n: number, max: number) {
-    return String(n).padStart(max, "0");
-  }
-  return `${pad(h, 2)}:${pad(m, 2)}:${pad(s, 2)}.${pad(ms, 3)}`;
+  return new Intl.DateTimeFormat("en-US", {
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    fractionalSecondDigits: 3,
+    hour12: false,
+  }).format(new Date());
 }

--- a/packages/utils-node/src/script.ts
+++ b/packages/utils-node/src/script.ts
@@ -46,7 +46,7 @@ export function $new(
 
     // verbose
     if (helperOptions.verbose) {
-      helperOptions.log(`$ ${command}`);
+      helperOptions.log(`[${formatNow()}] ${command}`);
     }
 
     // spawn
@@ -56,6 +56,19 @@ export function $new(
   // expose options in a self-referential way
   const api = Object.assign($, { _: {}, ...options });
   return api;
+}
+
+function formatNow() {
+  // cf. https://github.com/sindresorhus/execa/blob/f4b8b3ab601c94d1503f1010822952758dcc6350/lib/verbose.js#L10
+  const d = new Date();
+  const h = d.getHours();
+  const m = d.getMinutes();
+  const s = d.getSeconds();
+  const ms = d.getMilliseconds();
+  function pad(n: number, max: number) {
+    return String(n).padStart(max, "0");
+  }
+  return `${pad(h, 2)}:${pad(m, 2)}:${pad(s, 2)}.${pad(ms, 3)}`;
 }
 
 class SpawnPromiseLike implements PromiseLike<string> {

--- a/packages/utils-node/src/script.ts
+++ b/packages/utils-node/src/script.ts
@@ -77,7 +77,15 @@ class SpawnPromise implements PromiseLike<string> {
           }
           resolve(stdout);
         } else {
-          reject(new Error(`ChildProcess code ${code}`));
+          reject(
+            new Error(`ChildProcess error`, {
+              cause: {
+                code,
+                stdout: this.stdout,
+                stderr: this.stderr,
+              },
+            })
+          );
         }
       });
 

--- a/packages/utils-node/tsconfig.json
+++ b/packages/utils-node/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "types": ["@types/node"]
+  }
+}

--- a/packages/utils-node/tsup.config.ts
+++ b/packages/utils-node/tsup.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm", "cjs"],
+  dts: true,
+});

--- a/packages/utils/src/promise.ts
+++ b/packages/utils/src/promise.ts
@@ -49,3 +49,7 @@ export async function arrayFromAsyncGenerator<T>(
   }
   return result;
 }
+
+export function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(() => resolve(), ms));
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -230,6 +230,15 @@ importers:
 
   packages/utils-hattip: {}
 
+  packages/utils-node:
+    devDependencies:
+      '@hiogawa/utils':
+        specifier: workspace:*
+        version: link:../utils
+      '@types/node':
+        specifier: ^20.5.6
+        version: 20.5.6
+
   packages/utils-react:
     devDependencies:
       '@hiogawa/utils':
@@ -1665,6 +1674,10 @@ packages:
 
   /@types/node@20.4.1:
     resolution: {integrity: sha512-JIzsAvJeA/5iY6Y/OxZbv1lUcc8dNSE77lb2gnBH+/PJ3lFR1Ccvgwl5JWnHAkNHcRsT0TbpVOsiMKZ1F/yyJg==}
+    dev: true
+
+  /@types/node@20.5.6:
+    resolution: {integrity: sha512-Gi5wRGPbbyOTX+4Y2iULQ27oUPrefaB0PxGQJnfyWN3kvEDGM3mIB5M/gQLmitZf7A9FmLeaqxD3L1CXpm3VKQ==}
     dev: true
 
   /@types/normalize-package-data@2.4.1:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@hiogawa/isort-ts':
         specifier: 1.1.1
         version: 1.1.1(prettier@2.8.8)(typescript@5.1.6)
+      '@hiogawa/utils':
+        specifier: workspace:*
+        version: link:packages/utils
       '@hiogawa/utils-node':
         specifier: workspace:*
         version: link:packages/utils-node

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@hiogawa/isort-ts':
         specifier: 1.1.1
         version: 1.1.1(prettier@2.8.8)(typescript@5.1.6)
+      '@hiogawa/utils-node':
+        specifier: workspace:*
+        version: link:packages/utils-node
       '@tsconfig/strictest':
         specifier: ^2.0.1
         version: 2.0.1

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -41,6 +41,9 @@
       "path": "packages/utils-hattip"
     },
     {
+      "path": "packages/utils-node"
+    },
+    {
       "path": "packages/utils-react"
     }
   ]


### PR DESCRIPTION
Probably it could be a dedicated package ("tiny-script"? "script-helper"?), but for now let's just put it in as `utils-node`.

## todo

- [x] command error
  - just putting everything in `Error.cause` looks good enough

```sh
$ node misc/generate-tsconfig.mjs 
file:///home/hiroshi/code/personal/js-utils/packages/utils-node/dist/index.js:53
            new Error(`ScriptError`, {
            ^

Error: ScriptError
    at ChildProcess.<anonymous> (file:///home/hiroshi/code/personal/js-utils/packages/utils-node/dist/index.js:53:13)
    at ChildProcess.emit (node:events:513:28)
    at maybeClose (node:internal/child_process:1091:16)
    at ChildProcess._handle.onexit (node:internal/child_process:302:5) {
  [cause]: {
    command: "pnpm ls --filter './packages/**' --depth -1 --json --no-such-options",
    code: 1,
    stdout: " ERROR   ERROR  Unknown option: 'such-options'\n" +
      `Did you mean 'optional'? Use "--config.unknown=value" to force an unknown option.\n` +
      'For help, run: pnpm help list\n',
    stderr: ''
  }
}
```