### PR TITLE
feat(utils-node): add `$.new` for new instance with additive options 

### DIFF
--- a/misc/pre-release.mjs
+++ b/misc/pre-release.mjs
@@ -7,6 +7,7 @@ import fs from "node:fs";
 //   node misc/pre-release.mjs packages/utils-node
 
 $._.verbose = true;
+const $$ = $.new({ stdio: "inherit" });
 
 async function main() {
   const packageDir = process.argv[2];
@@ -33,13 +34,13 @@ async function main() {
   );
 
   // push
-  console.log(await $`git diff ${packageJsonPath}`);
+  await $$`git diff ${packageJsonPath}`;
   const input = await promptQuestion("* proceed to push changes? (y/n) ");
   if (input !== "y") process.exit(1);
 
-  await $`git add ${packageJsonPath}`;
-  await $`git commit -m 'chore: pre release (${pakcageJson.name}@${pakcageJson.version})'`;
-  await $`git push origin HEAD`;
+  await $$`git add ${packageJsonPath}`;
+  await $$`git commit -m 'chore: pre release (${pakcageJson.name}@${pakcageJson.version})'`;
+  await $$`git push origin HEAD`;
 }
 
 /**

--- a/packages/utils-node/package.json
+++ b/packages/utils-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/utils-node",
-  "version": "0.0.1-pre.4",
+  "version": "0.0.1-pre.5",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/utils-node/src/script.test.ts
+++ b/packages/utils-node/src/script.test.ts
@@ -1,6 +1,6 @@
 import { tinyassert, wrapErrorAsync } from "@hiogawa/utils";
 import { describe, expect, it, vi } from "vitest";
-import { $, $new } from "./script";
+import { $ } from "./script";
 
 describe("script", () => {
   it("basic", async () => {
@@ -8,13 +8,16 @@ describe("script", () => {
     expect(output).toMatchInlineSnapshot('"hello world"');
   });
 
-  it("helperOptions", async () => {
+  it("new", async () => {
     const logFn = vi.fn();
-    const $ = $new();
-    $._.noTrim = true;
-    $._.verbose = true;
-    $._.log = (v) => logFn(v.replace(/^\[\d{2}:\d{2}:\d{2}.\d{3}\]/, "[...]")); // reduct non-deterministic timestamp
-    const output = await $`echo ${"hello"} ${"world"}`;
+    const $$ = $.new({
+      _: {
+        noTrim: true,
+        verbose: true,
+        log: (v) => logFn(v.replace(/^\[\d{2}:\d{2}:\d{2}.\d{3}\]/, "[...]")), // reduct non-deterministic timestamp
+      },
+    });
+    const output = await $$`echo ${"hello"} ${"world"}`;
     expect(output).toMatchInlineSnapshot(`
       "hello world
       "

--- a/packages/utils-node/src/script.ts
+++ b/packages/utils-node/src/script.ts
@@ -20,9 +20,9 @@ type HelperOptions = {
 
 export const $ = /* @__PURE__ */ $new();
 
-export function $new(
-  options: SpawnOptions & { _?: Partial<HelperOptions> } = {}
-) {
+type NewOptions = SpawnOptions & { _?: Partial<HelperOptions> };
+
+export function $new(options: NewOptions = {}) {
   // currently there's no special quoting or escaping so it's equivalent to normal string literal template.
   // for now, limit to `string | number` since that's the same usage.
   function $(strings: TemplateStringsArray, ...params: (string | number)[]) {
@@ -56,7 +56,13 @@ export function $new(
   }
 
   // expose options in a self-referential way
-  const api = Object.assign($, { _: {}, ...options });
+  const api = Object.assign($, {
+    ...options,
+    _: { ...options._ },
+    // new instance with additive options
+    new: (options: NewOptions) =>
+      $new({ ...api, ...options, _: { ...api._, ...options._ } }),
+  });
   return api;
 }
 


### PR DESCRIPTION

## example

```sh
$ node misc/pre-release.mjs packages/utils-node
[13:09:04.661] git status --porcelain
[13:09:04.672] git diff packages/utils-node/package.json
diff --git a/packages/utils-node/package.json b/packages/utils-node/package.json
index d9524bb..bee5e19 100644
--- a/packages/utils-node/package.json
+++ b/packages/utils-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/utils-node",
-  "version": "0.0.1-pre.4",
+  "version": "0.0.1-pre.5",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",
* proceed to push changes? (y/n) y
[13:09:07.154] git add packages/utils-node/package.json
[13:09:07.166] git commit -m 'chore: pre release (@hiogawa/utils-node@0.0.1-pre.5)'
[feat-utils-node-additive-instantiation 383378b] chore: pre release (@hiogawa/utils-node@0.0.1-pre.5)
 1 file changed, 1 insertion(+), 1 deletion(-)
[13:09:07.315] git push origin HEAD
오브젝트 나열하는 중: 23, 완료.
오브젝트 개수 세는 중: 100% (23/23), 완료.
Delta compression using up to 8 threads
오브젝트 압축하는 중: 100% (14/14), 완료.
오브젝트 쓰는 중: 100% (14/14), 2.60 KiB | 2.60 MiB/s, 완료.
Total 14 (delta 10), reused 0 (delta 0), pack-reused 0
remote: Resolving deltas: 100% (10/10), completed with 7 local objects.
remote: 
remote: Create a pull request for 'feat-utils-node-additive-instantiation' on GitHub by visiting:
remote:      https://github.com/hi-ogawa/js-utils/pull/new/feat-utils-node-additive-instantiation
remote: 
To github.com:hi-ogawa/js-utils.git
 * [new branch]      HEAD -> feat-utils-node-additive-instantiation
```