### PR TITLE
refactor(tiny-sql)!: use snake case column `executed_at` + add postgresql example

### DIFF
--- a/.changeset/lucky-pillows-double.md
+++ b/.changeset/lucky-pillows-double.md
@@ -1,0 +1,5 @@
+---
+"@hiogawa/tiny-sql": major
+---
+
+refactor: use snake case column for "executed_at"

--- a/misc/pre-release.mjs
+++ b/misc/pre-release.mjs
@@ -21,32 +21,35 @@ async function main() {
     const input = await promptQuestion(
       "* proceed regardless of dirty 'git status'? (Y/n) "
     );
-    if (["", "y"].includes(input)) process.exit(1);
+    if (!["", "y"].includes(input)) process.exit(1);
   }
 
   // update version
-  /** @type {{ version: string }} */
   const pakcageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8"));
-  pakcageJson.version = getNextVersion(pakcageJson.version);
+  const nextVersion = getNextVersion(pakcageJson.version);
+  console.log("* version change");
+  console.log(colors.red(`- ${pakcageJson.version}`));
+  console.log(colors.green(`+ ${nextVersion}`));
+  const input = await promptQuestion("* proceed to push changes? (y/n) ");
+  if (!["", "y"].includes(input)) process.exit(1);
+
+  // write file
+  pakcageJson.version = nextVersion;
   fs.writeFileSync(
     packageJsonPath,
     JSON.stringify(pakcageJson, null, 2) + "\n"
   );
 
   // push
-  await $$`git diff ${packageJsonPath}`;
-  const input = await promptQuestion("* proceed to push changes? (y/n) ");
-  if (["", "y"].includes(input)) process.exit(1);
-
   await $$`git add ${packageJsonPath}`;
   await $$`git commit -m 'chore: pre release (${pakcageJson.name}@${pakcageJson.version})'`;
   await $$`git push origin HEAD`;
 }
 
-/**
- * @param {string} version
- */
-function getNextVersion(version) {
+function getNextVersion(
+  /** @type {string} */
+  version
+) {
   const vs = version.match(/(\d+).(\d+).(\d+)(?:-pre.(\d+))?/).slice(1);
   if (vs[3]) {
     vs[3] = Number(vs[3]) + 1;
@@ -56,5 +59,10 @@ function getNextVersion(version) {
   }
   return vs.slice(0, -1).join(".") + "-pre." + vs[3];
 }
+
+const colors = {
+  red: (v) => `\u001B[31m${v}\u001B[39m`,
+  green: (v) => `\u001B[32m${v}\u001B[39m`,
+};
 
 main();

--- a/misc/pre-release.mjs
+++ b/misc/pre-release.mjs
@@ -19,9 +19,9 @@ async function main() {
   if (gitStatus) {
     console.log(gitStatus);
     const input = await promptQuestion(
-      "* proceed regardless of dirty 'git status'? (y/n) "
+      "* proceed regardless of dirty 'git status'? (Y/n) "
     );
-    if (input !== "y") process.exit(1);
+    if (["", "y"].includes(input)) process.exit(1);
   }
 
   // update version
@@ -36,7 +36,7 @@ async function main() {
   // push
   await $$`git diff ${packageJsonPath}`;
   const input = await promptQuestion("* proceed to push changes? (y/n) ");
-  if (input !== "y") process.exit(1);
+  if (["", "y"].includes(input)) process.exit(1);
 
   await $$`git add ${packageJsonPath}`;
   await $$`git commit -m 'chore: pre release (${pakcageJson.name}@${pakcageJson.version})'`;

--- a/packages/tiny-sql/examples/postgresql/Makefile
+++ b/packages/tiny-sql/examples/postgresql/Makefile
@@ -1,0 +1,17 @@
+# everything phony
+.PHONY: $(shell grep --no-filename -E '^([a-zA-Z_-]|/)+:' $(MAKEFILE_LIST) | sed 's/:.*//')
+
+docker/up:
+	docker compose up -d
+	docker compose run --rm dockerize -wait tcp://postgres:5432
+
+docker/down:
+	docker compose down
+
+docker/clean:
+	docker compose down -v --remove-orphans
+	docker compose rm -f -s -v
+
+db/reset:
+	docker compose exec -T postgres psql postgres postgres -c 'DROP DATABASE IF EXISTS "development"' -c 'CREATE DATABASE "development"'
+	pnpm migrate init-latest

--- a/packages/tiny-sql/examples/postgresql/Makefile
+++ b/packages/tiny-sql/examples/postgresql/Makefile
@@ -2,8 +2,7 @@
 .PHONY: $(shell grep --no-filename -E '^([a-zA-Z_-]|/)+:' $(MAKEFILE_LIST) | sed 's/:.*//')
 
 docker/up:
-	docker compose up -d
-	docker compose run --rm dockerize -wait tcp://postgres:5432
+	docker compose up --wait
 
 docker/down:
 	docker compose down

--- a/packages/tiny-sql/examples/postgresql/Makefile
+++ b/packages/tiny-sql/examples/postgresql/Makefile
@@ -11,6 +11,9 @@ docker/clean:
 	docker compose down -v --remove-orphans
 	docker compose rm -f -s -v
 
+db/create:
+	docker compose exec -T postgres psql postgres postgres -c 'CREATE DATABASE "development"'
+
 db/reset:
 	docker compose exec -T postgres psql postgres postgres -c 'DROP DATABASE IF EXISTS "development"' -c 'CREATE DATABASE "development"'
 	pnpm migrate init-latest

--- a/packages/tiny-sql/examples/postgresql/README.md
+++ b/packages/tiny-sql/examples/postgresql/README.md
@@ -3,4 +3,6 @@
 ```sh
 make docker/up db/reset
 npx vitest
+
+base misc/test.sh
 ```

--- a/packages/tiny-sql/examples/postgresql/README.md
+++ b/packages/tiny-sql/examples/postgresql/README.md
@@ -1,0 +1,6 @@
+# tiny-sql/examples/sqlite
+
+```sh
+make docker/up db/reset
+npx vitest
+```

--- a/packages/tiny-sql/examples/postgresql/docker-compose.yml
+++ b/packages/tiny-sql/examples/postgresql/docker-compose.yml
@@ -1,0 +1,18 @@
+version: "3.5"
+
+services:
+  postgres:
+    image: postgres:alpine
+    ports:
+      - 6432:5432
+    environment:
+      - POSTGRES_PASSWORD=password
+    volumes:
+      - postgres-volume:/var/lib/postgresql/data
+
+  dockerize:
+    image: jwilder/dockerize:0.6.1
+    profiles: ["tools"]
+
+volumes:
+  postgres-volume:

--- a/packages/tiny-sql/examples/postgresql/docker-compose.yml
+++ b/packages/tiny-sql/examples/postgresql/docker-compose.yml
@@ -9,10 +9,10 @@ services:
       - POSTGRES_PASSWORD=password
     volumes:
       - postgres-volume:/var/lib/postgresql/data
-
-  dockerize:
-    image: jwilder/dockerize:0.6.1
-    profiles: ["tools"]
+    healthcheck:
+      test:  psql postgres postgres -c 'SELECT 0'
+      interval: 1s
+      retries: 10
 
 volumes:
   postgres-volume:

--- a/packages/tiny-sql/examples/postgresql/docker-compose.yml
+++ b/packages/tiny-sql/examples/postgresql/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     volumes:
       - postgres-volume:/var/lib/postgresql/data
     healthcheck:
-      test:  psql postgres postgres -c 'SELECT 0'
+      test: pg_isready
       interval: 1s
       retries: 10
 

--- a/packages/tiny-sql/examples/postgresql/misc/test.sh
+++ b/packages/tiny-sql/examples/postgresql/misc/test.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -eu -o pipefail
+
+make docker/clean
+make docker/up
+make db/create
+pnpm -s migrate init
+pnpm -s migrate status
+pnpm -s migrate latest
+pnpm -s migrate status
+npx vitest run
+pnpm -s migrate down
+pnpm -s migrate status
+pnpm -s migrate up
+make docker/clean

--- a/packages/tiny-sql/examples/postgresql/package.json
+++ b/packages/tiny-sql/examples/postgresql/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "tiny-sql-examples-postgresql",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "repl": "tsx -r ./src/repl.ts",
+    "migrate": "tsx ./src/migrate.ts"
+  },
+  "devDependencies": {
+    "@hiogawa/tiny-sql": "workspace:*",
+    "@hiogawa/utils": "workspace:*",
+    "postgres": "^3.3.5"
+  }
+}

--- a/packages/tiny-sql/examples/postgresql/src/db.test.ts
+++ b/packages/tiny-sql/examples/postgresql/src/db.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { sql } from "./db";
+
+describe("db", () => {
+  it("basic", async () => {
+    const rows = await sql`select * from counter`;
+    expect(rows).toMatchInlineSnapshot(`
+      Result [
+        {
+          "id": 1,
+          "value": 0,
+        },
+      ]
+    `);
+  });
+});

--- a/packages/tiny-sql/examples/postgresql/src/db.ts
+++ b/packages/tiny-sql/examples/postgresql/src/db.ts
@@ -1,0 +1,6 @@
+import process from "node:process";
+import postgres from "postgres";
+
+const devUrl = "postgres://postgres:password@localhost:6432/development";
+const url = process.env["DATABASE_URL"] ?? devUrl;
+export const sql = postgres(url);

--- a/packages/tiny-sql/examples/postgresql/src/db.ts
+++ b/packages/tiny-sql/examples/postgresql/src/db.ts
@@ -2,5 +2,15 @@ import process from "node:process";
 import postgres from "postgres";
 
 const devUrl = "postgres://postgres:password@localhost:6432/development";
+
 const url = process.env["DATABASE_URL"] ?? devUrl;
-export const sql = postgres(url);
+
+const debugSql = Boolean(process.env["DEBUG"]?.includes("sql"));
+
+export const sql = postgres(url, {
+  debug(connection, query, parameters, paramTypes) {
+    if (debugSql) {
+      console.log(`[debug:sql:${connection}] ${query}`, parameters, paramTypes);
+    }
+  },
+});

--- a/packages/tiny-sql/examples/postgresql/src/migrate.ts
+++ b/packages/tiny-sql/examples/postgresql/src/migrate.ts
@@ -1,0 +1,42 @@
+import process from "node:process";
+import {
+  Migrator,
+  MigratorCli,
+  rawSqlMigrationDriver,
+  rawSqlMigrationProvider,
+} from "@hiogawa/tiny-sql";
+import { formatError } from "@hiogawa/utils";
+import { sql } from "./db";
+
+async function main() {
+  const args = process.argv.slice(2);
+
+  const migrator = new Migrator({
+    provider: rawSqlMigrationProvider({ directory: "src/migrations" }),
+    driver: rawSqlMigrationDriver({
+      table: "migrations",
+      async execute(query) {
+        return sql.unsafe(query);
+      },
+      async executeRaw(query) {
+        await sql.unsafe(query);
+      },
+    }),
+  });
+
+  const migratorCli = new MigratorCli(migrator);
+  await migratorCli.parseAndRun(args);
+}
+
+async function mainWrapper() {
+  try {
+    await main();
+  } catch (error) {
+    console.log(formatError(error));
+    process.exitCode = 1;
+  } finally {
+    await sql.end();
+  }
+}
+
+mainWrapper();

--- a/packages/tiny-sql/examples/postgresql/src/migrations/2023-07-08-11-49-30-create-table-counter/down.sql
+++ b/packages/tiny-sql/examples/postgresql/src/migrations/2023-07-08-11-49-30-create-table-counter/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE "counter";

--- a/packages/tiny-sql/examples/postgresql/src/migrations/2023-07-08-11-49-30-create-table-counter/up.sql
+++ b/packages/tiny-sql/examples/postgresql/src/migrations/2023-07-08-11-49-30-create-table-counter/up.sql
@@ -1,0 +1,6 @@
+CREATE TABLE "counter" (
+    "id" SERIAL NOT NULL,
+    "value" INTEGER NOT NULL,
+    CONSTRAINT "counter_pkey" PRIMARY KEY ("id")
+);
+INSERT INTO "counter" (id, value) VALUES (1, 0);

--- a/packages/tiny-sql/examples/postgresql/src/repl.ts
+++ b/packages/tiny-sql/examples/postgresql/src/repl.ts
@@ -1,0 +1,13 @@
+import { sql } from "./db";
+
+Object.assign(globalThis, { sql });
+
+/*
+
+$ pnpm -s repl
+Welcome to Node.js v18.16.0.
+Type ".help" for more information.
+> await sql`SELECT 1 + 1 as two`
+Result(1) [ { two: 2 } ]
+
+*/

--- a/packages/tiny-sql/examples/postgresql/tsconfig.json
+++ b/packages/tiny-sql/examples/postgresql/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src"]
+}

--- a/packages/tiny-sql/package.json
+++ b/packages/tiny-sql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/tiny-sql",
-  "version": "0.0.4",
+  "version": "0.0.5-pre.0",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/tiny-sql/src/migrator-cli.ts
+++ b/packages/tiny-sql/src/migrator-cli.ts
@@ -20,7 +20,7 @@ export class MigratorCli {
         const result = await this.migrator.status();
         console.log("[migration-status]");
         for (const [name, e] of result.map) {
-          console.log(name, ":", e.state?.executedAt ?? "(pending)");
+          console.log(name, ":", e.state?.executed_at ?? "(pending)");
         }
         return;
       }

--- a/packages/tiny-sql/src/migrator-helper.ts
+++ b/packages/tiny-sql/src/migrator-helper.ts
@@ -57,13 +57,13 @@ export function rawSqlMigrationDriver(options: {
   execute: (query: string) => Promise<unknown[]>;
   executeRaw: (query: string) => Promise<void>;
 }): MigratorOptions<string>["driver"] {
-  // TODO: escape/binding?
+  // TODO: quote/escape/binding?
   return {
     init: async () => {
       await options.execute(`\
         CREATE TABLE ${options.table} (
-          name       VARCHAR(128) NOT NULL PRIMARY KEY,
-          executedAt VARCHAR(128) NOT NULL
+          name        VARCHAR(128) NOT NULL PRIMARY KEY,
+          executed_at VARCHAR(128) NOT NULL
         )
       `);
     },
@@ -81,7 +81,7 @@ export function rawSqlMigrationDriver(options: {
 
     insert: async (state) => {
       await options.execute(
-        `INSERT INTO ${options.table} (name, executedAt) VALUES ('${state.name}', '${state.executedAt}')`
+        `INSERT INTO ${options.table} (name, executed_at) VALUES ('${state.name}', '${state.executed_at}')`
       );
     },
 

--- a/packages/tiny-sql/src/migrator.test.ts
+++ b/packages/tiny-sql/src/migrator.test.ts
@@ -125,7 +125,7 @@ describe(Migrator, () => {
               "up": "up:create-user",
             },
             "state": {
-              "executedAt": "1970-01-01T00:00:01.000Z",
+              "executed_at": "1970-01-01T00:00:01.000Z",
               "name": "create-user",
             },
           },
@@ -163,7 +163,7 @@ describe(Migrator, () => {
     expect(table).toMatchInlineSnapshot(`
       [
         {
-          "executedAt": "1970-01-01T00:00:01.000Z",
+          "executed_at": "1970-01-01T00:00:01.000Z",
           "name": "create-user",
         },
       ]
@@ -189,11 +189,11 @@ describe(Migrator, () => {
     expect(table).toMatchInlineSnapshot(`
       [
         {
-          "executedAt": "1970-01-01T00:00:01.000Z",
+          "executed_at": "1970-01-01T00:00:01.000Z",
           "name": "create-user",
         },
         {
-          "executedAt": "1970-01-01T00:00:02.000Z",
+          "executed_at": "1970-01-01T00:00:02.000Z",
           "name": "up-only",
         },
       ]
@@ -220,7 +220,7 @@ describe(Migrator, () => {
     expect(table).toMatchInlineSnapshot(`
       [
         {
-          "executedAt": "1970-01-01T00:00:01.000Z",
+          "executed_at": "1970-01-01T00:00:01.000Z",
           "name": "create-user",
         },
       ]
@@ -252,15 +252,15 @@ describe(Migrator, () => {
     expect(table).toMatchInlineSnapshot(`
       [
         {
-          "executedAt": "1970-01-01T00:00:01.000Z",
+          "executed_at": "1970-01-01T00:00:01.000Z",
           "name": "create-user",
         },
         {
-          "executedAt": "1970-01-01T00:00:04.000Z",
+          "executed_at": "1970-01-01T00:00:04.000Z",
           "name": "up-only",
         },
         {
-          "executedAt": "1970-01-01T00:00:04.000Z",
+          "executed_at": "1970-01-01T00:00:04.000Z",
           "name": "create-profile",
         },
       ]
@@ -289,11 +289,11 @@ describe(Migrator, () => {
     expect(table).toMatchInlineSnapshot(`
       [
         {
-          "executedAt": "1970-01-01T00:00:01.000Z",
+          "executed_at": "1970-01-01T00:00:01.000Z",
           "name": "create-user",
         },
         {
-          "executedAt": "1970-01-01T00:00:04.000Z",
+          "executed_at": "1970-01-01T00:00:04.000Z",
           "name": "up-only",
         },
       ]
@@ -464,7 +464,7 @@ describe(Migrator, () => {
                 "up": "up:m2",
               },
               "state": {
-                "executedAt": "1970-01-01T00:00:00.000Z",
+                "executed_at": "1970-01-01T00:00:00.000Z",
                 "name": "m2",
               },
             },
@@ -517,7 +517,7 @@ describe(Migrator, () => {
                 "up": "up:m1",
               },
               "state": {
-                "executedAt": "1970-01-01T00:00:00.000Z",
+                "executed_at": "1970-01-01T00:00:00.000Z",
                 "name": "m1",
               },
             },
@@ -528,7 +528,7 @@ describe(Migrator, () => {
                 "up": "up:m2",
               },
               "state": {
-                "executedAt": "1970-01-01T00:00:00.000Z",
+                "executed_at": "1970-01-01T00:00:00.000Z",
                 "name": "m2",
               },
             },
@@ -565,7 +565,7 @@ describe(Migrator, () => {
                 "up": "up:m1",
               },
               "state": {
-                "executedAt": "1970-01-01T00:00:00.000Z",
+                "executed_at": "1970-01-01T00:00:00.000Z",
                 "name": "m1",
               },
             },

--- a/packages/tiny-sql/src/migrator.ts
+++ b/packages/tiny-sql/src/migrator.ts
@@ -26,7 +26,7 @@ export type MigrationRequest<I> = {
 
 export interface MigrationState {
   name: string;
-  executedAt: string;
+  executed_at: string;
 }
 
 export type MigrationRequestStateMap<I> = Map<
@@ -149,8 +149,8 @@ export class Migrator<T = unknown> {
   ) {
     if (direction === "up") {
       await this.options.driver.run(request.up);
-      const executedAt = new Date().toISOString();
-      await this.options.driver.insert({ name: request.name, executedAt });
+      const executed_at = new Date().toISOString();
+      await this.options.driver.insert({ name: request.name, executed_at });
     } else {
       if (request.down) {
         await this.options.driver.run(request.down);

--- a/packages/tiny-sql/tsup.config.ts
+++ b/packages/tiny-sql/tsup.config.ts
@@ -1,7 +1,6 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  clean: true,
   entry: ["src/index.ts"],
   format: ["esm", "cjs"],
   dts: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -229,6 +229,18 @@ importers:
         specifier: ^20.4.1
         version: 20.4.1
 
+  packages/tiny-sql/examples/postgresql:
+    devDependencies:
+      '@hiogawa/tiny-sql':
+        specifier: workspace:*
+        version: link:../..
+      '@hiogawa/utils':
+        specifier: workspace:*
+        version: link:../../../utils
+      postgres:
+        specifier: ^3.3.5
+        version: 3.3.5
+
   packages/tiny-sql/examples/sqlite:
     devDependencies:
       '@hiogawa/tiny-sql':
@@ -4451,6 +4463,10 @@ packages:
       nanoid: 3.3.6
       picocolors: 1.0.0
       source-map-js: 1.0.2
+    dev: true
+
+  /postgres@3.3.5:
+    resolution: {integrity: sha512-+JD93VELV9gHkqpV5gdL5/70HdGtEw4/XE1S4BC8f1mcPmdib3K5XsKVbnR1XcAyC41zOnifJ+9YRKxdIsXiUw==}
     dev: true
 
   /prebuild-install@7.1.1:


### PR DESCRIPTION
Spin up docker-compose during `pnpm test` sounds too much, so the tests are not hooked into ci.