### PR TITLE
feat(utils): add ansi 3bit color utils

### DIFF
--- a/.changeset/weak-deers-attack.md
+++ b/.changeset/weak-deers-attack.md
@@ -1,0 +1,5 @@
+---
+"@hiogawa/utils": minor
+---
+
+feat: add ansi 3bit color utils

--- a/misc/pre-release.mjs
+++ b/misc/pre-release.mjs
@@ -1,5 +1,5 @@
 import process from "node:process";
-import { tinyassert } from "@hiogawa/utils";
+import { tinyassert, colors, formatError } from "@hiogawa/utils";
 import { $, promptQuestion } from "@hiogawa/utils-node";
 import fs from "node:fs";
 
@@ -60,9 +60,4 @@ function getNextVersion(
   return vs.slice(0, -1).join(".") + "-pre." + vs[3];
 }
 
-const colors = {
-  red: (v) => `\u001B[31m${v}\u001B[39m`,
-  green: (v) => `\u001B[32m${v}\u001B[39m`,
-};
-
-main();
+main().catch((e) => console.error(formatError(e)));

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/utils",
-  "version": "1.6.1-pre.2",
+  "version": "1.6.1-pre.3",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/utils/src/colors.ts
+++ b/packages/utils/src/colors.ts
@@ -1,0 +1,29 @@
+// 3 bit ansi colors (nested usage are not supported)
+// https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_(Select_Graphic_Rendition)_parameters
+// https://en.wikipedia.org/wiki/ANSI_escape_code#3-bit_and_4-bit
+// https://github.com/chalk/chalk
+// https://github.com/alexeyraspopov/picocolors
+const baseColors = [
+  "black",
+  "red",
+  "green",
+  "yellow",
+  "blue",
+  "magenta",
+  "cyan",
+  "white",
+] as const;
+type BaseColor = (typeof baseColors)[number];
+type Color = BaseColor | `bg${Capitalize<BaseColor>}`;
+
+export const colors = /* @__PURE__ */ Object.fromEntries(
+  baseColors.flatMap((fg, i) => {
+    const bg = `bg${fg.slice(0, 1).toUpperCase()}${fg.slice(1)}`;
+    return [
+      // fg: 30..
+      // bg: 40..
+      [fg, (v: string) => `\u001B[${30 + i}m${v}\u001B[39m`],
+      [bg, (v: string) => `\u001B[${40 + i}m${v}\u001B[49m`],
+    ] as any;
+  })
+) as Record<Color, (v: string) => string>;

--- a/packages/utils/src/error.ts
+++ b/packages/utils/src/error.ts
@@ -44,7 +44,7 @@ function formatErrorInner(
 
   if (color) {
     label = colors.bgRed(` ${label} `);
-    stack = colors.cyan(stack);
+    stack = stack && colors.cyan(stack);
   } else {
     label = `[${label}]`;
   }

--- a/packages/utils/src/error.ts
+++ b/packages/utils/src/error.ts
@@ -35,6 +35,7 @@ export function formatError(
   return errorsString.join("\n");
 }
 
+// based on consola.error https://github.com/unjs/consola
 function formatErrorInner(
   label: string,
   e: Pick<Error, "message" | "stack">,

--- a/packages/utils/src/error.ts
+++ b/packages/utils/src/error.ts
@@ -1,3 +1,5 @@
+import { colors } from "./colors";
+
 // traverse and error Error.cause chain
 export function flattenErrorCauses(e: unknown): unknown[] {
   let errors: unknown[] = [e];
@@ -33,11 +35,6 @@ export function formatError(
   return errorsString.join("\n");
 }
 
-// cf. consola.error
-// https://github.com/unjs/consola/blob/e4a37c1cd2c8d96b5f30d8c13ff2df32244baa6a/src/utils/color.ts#L93
-// https://github.com/unjs/consola/blob/e4a37c1cd2c8d96b5f30d8c13ff2df32244baa6a/src/reporters/fancy.ts#L49
-// https://github.com/unjs/consola/blob/e4a37c1cd2c8d96b5f30d8c13ff2df32244baa6a/src/reporters/fancy.ts#L64-L65
-// https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_(Select_Graphic_Rendition)_parameters
 function formatErrorInner(
   label: string,
   e: Pick<Error, "message" | "stack">,
@@ -46,8 +43,8 @@ function formatErrorInner(
   let stack = e.stack?.split("\n").slice(1).join("\n") ?? "";
 
   if (color) {
-    label = `\u001B[41m ${label} \u001B[49m`;
-    stack = stack && `\u001B[36m${stack}\u001B[39m`;
+    label = colors.bgRed(` ${label} `);
+    stack = colors.cyan(stack);
   } else {
     label = `[${label}]`;
   }

--- a/packages/utils/src/index.test.ts
+++ b/packages/utils/src/index.test.ts
@@ -610,5 +610,8 @@ describe("colors", () => {
   it("basic", () => {
     expect(colors.red("hey")).toMatchInlineSnapshot('"[31mhey[39m"');
     expect(colors.bgRed("yo")).toMatchInlineSnapshot('"[41myo[49m"');
+    expect(
+      colors.cyan(`nesting ${colors.red("not")} supported`)
+    ).toMatchInlineSnapshot('"[36mnesting [31mnot[39m supported[39m"');
   });
 });

--- a/packages/utils/src/index.test.ts
+++ b/packages/utils/src/index.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { colors } from "./colors";
 import { defaultDict } from "./default-dict";
 import { DefaultMap, HashKeyDefaultMap, UncheckedMap } from "./default-map";
 import { groupBy, range } from "./lodash";
@@ -602,5 +603,12 @@ describe(mapRegExp, () => {
     expect(transform("x = {{ 1 + 2 }}, y = {{ 4 * 5 }}")).toMatchInlineSnapshot(
       '"x = 3, y = 20"'
     );
+  });
+});
+
+describe("colors", () => {
+  it("basic", () => {
+    expect(colors.red("hey")).toMatchInlineSnapshot('"[31mhey[39m"');
+    expect(colors.bgRed("yo")).toMatchInlineSnapshot('"[41myo[49m"');
   });
 });

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -10,3 +10,4 @@ export * from "./hash";
 export * from "./regexp";
 export * from "./error";
 export * from "./cache";
+export * from "./colors";


### PR DESCRIPTION
For simple usages, I can code-golf a bit further picocolors (https://github.com/alexeyraspopov/picocolors/blob/b6261487e7b81aaab2440e397a356732cad9e342/picocolors.js) and it should be convenient enough.