### PR TITLE
chore(utils): fix PURE comment for colors

### DIFF
--- a/packages/utils/src/colors.ts
+++ b/packages/utils/src/colors.ts
@@ -16,14 +16,13 @@ const baseColors = [
 type BaseColor = (typeof baseColors)[number];
 type Color = BaseColor | `bg${Capitalize<BaseColor>}`;
 
-export const colors = /* @__PURE__ */ Object.fromEntries(
-  baseColors.flatMap((fg, i) => {
-    const bg = `bg${fg.slice(0, 1).toUpperCase()}${fg.slice(1)}`;
-    return [
-      // fg: 30..
-      // bg: 40..
-      [fg, (v: string) => `\u001B[${30 + i}m${v}\u001B[39m`],
-      [bg, (v: string) => `\u001B[${40 + i}m${v}\u001B[49m`],
-    ] as any;
-  })
-) as Record<Color, (v: string) => string>;
+export const colors = /* @__PURE__ */ (() =>
+  Object.fromEntries(
+    baseColors.flatMap((fg, i) => {
+      const bg = `bg${fg.slice(0, 1).toUpperCase()}${fg.slice(1)}`;
+      return [
+        [fg, (v: string) => `\u001B[${30 + i}m${v}\u001B[39m`],
+        [bg, (v: string) => `\u001B[${40 + i}m${v}\u001B[49m`],
+      ] as any;
+    })
+  ) as Record<Color, (v: string) => string>)();


### PR DESCRIPTION
- follow up https://github.com/hi-ogawa/js-utils/pull/115

It seems it needs to wrap into single function for PURE to work.
For example, previously unused `colors` popped up in `packages/json-extra/dist/index.js`:

```js
// packages/json-extra/dist/index.js
var baseColors = [
  "black",
  "red",
  "green",
  "yellow",
  "blue",
  "magenta",
  "cyan",
  "white"
];
var colors = /* @__PURE__ */ Object.fromEntries(
  baseColors.flatMap((fg, i) => {
    const bg = `bg${fg.slice(0, 1).toUpperCase()}${fg.slice(1)}`;
    return [
      // fg: 30..
      // bg: 40..
      [fg, (v) => `\x1B[${30 + i}m${v}\x1B[39m`],
      [bg, (v) => `\x1B[${40 + i}m${v}\x1B[49m`]
    ];
  })
);
```