### PR TITLE
feat(utils): add more ansi escape codes

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/utils",
-  "version": "1.6.1-pre.4",
+  "version": "1.6.1-pre.5",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/utils/src/colors.ts
+++ b/packages/utils/src/colors.ts
@@ -1,28 +1,36 @@
-// 3 bit ansi colors (nested usage are not supported)
+// ansi escape codes
 // https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_(Select_Graphic_Rendition)_parameters
-// https://en.wikipedia.org/wiki/ANSI_escape_code#3-bit_and_4-bit
 // https://github.com/chalk/chalk
 // https://github.com/alexeyraspopov/picocolors
-const baseColors = [
-  "black",
-  "red",
-  "green",
-  "yellow",
-  "blue",
-  "magenta",
-  "cyan",
-  "white",
+const codes = [
+  // 3 bit fg/bg colors
+  ["black", 30, 39],
+  ["red", 31, 39],
+  ["green", 32, 39],
+  ["yellow", 33, 39],
+  ["blue", 34, 39],
+  ["magenta", 35, 39],
+  ["cyan", 36, 39],
+  ["white", 37, 39],
+  ["bgBlack", 40, 49],
+  ["bgRed", 41, 49],
+  ["bgGreen", 42, 49],
+  ["bgYellow", 43, 49],
+  ["bgBlue", 44, 49],
+  ["bgMagenta", 45, 49],
+  ["bgCyan", 46, 49],
+  ["bgWhite", 47, 49],
+  // styles
+  ["bold", 1, 22],
+  ["dim", 2, 22],
+  ["underline", 4, 24],
+  ["inverse", 7, 27],
 ] as const;
-type BaseColor = (typeof baseColors)[number];
-type Color = BaseColor | `bg${Capitalize<BaseColor>}`;
 
 export const colors = /* @__PURE__ */ (() =>
   Object.fromEntries(
-    baseColors.flatMap((fg, i) => {
-      const bg = `bg${fg.slice(0, 1).toUpperCase()}${fg.slice(1)}`;
-      return [
-        [fg, (v: string) => `\u001B[${30 + i}m${v}\u001B[39m`],
-        [bg, (v: string) => `\u001B[${40 + i}m${v}\u001B[49m`],
-      ];
-    })
-  ) as Record<Color, (v: string) => string>)();
+    codes.map(([name, start, end]) => [
+      name,
+      (v: string) => `\u001B[${start}m${v}\u001B[${end}m`,
+    ])
+  ) as Record<(typeof codes)[number][0], (v: string) => string>)();

--- a/packages/utils/src/index.test.ts
+++ b/packages/utils/src/index.test.ts
@@ -612,17 +612,20 @@ describe("colors", () => {
   it("basic", () => {
     expect(colors.red("hey")).toMatchInlineSnapshot('"[31mhey[39m"');
     expect(colors.bgRed("yo")).toMatchInlineSnapshot('"[41myo[49m"');
+    expect(
+      colors.bold(colors.inverse(colors.magenta(" ERROR ")))
+    ).toMatchInlineSnapshot('"[1m[7m[35m ERROR [39m[27m[22m"');
   });
 
   it("all", () => {
-    let strings = Object.entries(colors).map(([k, v]) => v(k));
-    strings = sortBy(strings, (v) => v.includes("bg"));
+    const strings = Object.entries(colors).map(([k, v]) => v(k));
     const formated = splitByChunk(strings, 8)
       .map((vs) => vs.join(" "))
       .join("\n");
     expect(formated).toMatchInlineSnapshot(`
       "[30mblack[39m [31mred[39m [32mgreen[39m [33myellow[39m [34mblue[39m [35mmagenta[39m [36mcyan[39m [37mwhite[39m
-      [40mbgBlack[49m [41mbgRed[49m [42mbgGreen[49m [43mbgYellow[49m [44mbgBlue[49m [45mbgMagenta[49m [46mbgCyan[49m [47mbgWhite[49m"
+      [40mbgBlack[49m [41mbgRed[49m [42mbgGreen[49m [43mbgYellow[49m [44mbgBlue[49m [45mbgMagenta[49m [46mbgCyan[49m [47mbgWhite[49m
+      [1mbold[22m [2mdim[22m [4munderline[24m [7minverse[27m"
     `);
   });
 

--- a/packages/utils/src/index.test.ts
+++ b/packages/utils/src/index.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { colors } from "./colors";
 import { defaultDict } from "./default-dict";
 import { DefaultMap, HashKeyDefaultMap, UncheckedMap } from "./default-map";
-import { groupBy, range, sortBy, splitByChunk } from "./lodash";
+import { groupBy, range, splitByChunk } from "./lodash";
 import {
   arrayToEnum,
   assertUnreachable,


### PR DESCRIPTION
I guess we just ended up hard-coding codes which is way simpler...