### PR TITLE
feat(utils): handle optional key for object utils

### DIFF
--- a/.changeset/big-mice-design.md
+++ b/.changeset/big-mice-design.md
@@ -1,0 +1,5 @@
+---
+"@hiogawa/utils": minor
+---
+
+feat: relax object utils typings

--- a/packages/utils/src/lodash.test.ts
+++ b/packages/utils/src/lodash.test.ts
@@ -18,6 +18,7 @@ import {
   objectKeys,
   objectMapKeys,
   objectMapValues,
+  objectMapValues2,
   objectOmit,
   objectOmitBy,
   objectPick,
@@ -427,6 +428,30 @@ describe(objectMapValues, () => {
       {
         "x": "x",
         "y": "yy",
+      }
+    `);
+  });
+
+  it("optional", () => {
+    interface TestOptional {
+      x: number;
+      y?: number;
+      z?: number;
+    }
+    const o: TestOptional = {
+      x: 3,
+      z: undefined,
+    };
+    const result = objectMapValues2(o, (v, k) => (v ? k.repeat(v) : "bad"));
+    result satisfies {
+      x: string;
+      y?: string;
+      z?: string;
+    };
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "x": "xxx",
+        "z": "bad",
       }
     `);
   });

--- a/packages/utils/src/lodash.test.ts
+++ b/packages/utils/src/lodash.test.ts
@@ -18,7 +18,6 @@ import {
   objectKeys,
   objectMapKeys,
   objectMapValues,
-  objectMapValues2,
   objectOmit,
   objectOmitBy,
   objectPick,
@@ -416,20 +415,32 @@ describe(`${objectEntries.name}/${objectFromEntries.name}`, () => {
   });
 });
 
-describe(objectMapValues, () => {
+describe(`${objectMapValues.name}/${objectMapKeys.name}`, () => {
   it("basic", () => {
     const o = {
       x: 1,
       y: 2,
     };
-    const result = objectMapValues(o, (v, k) => k.repeat(v));
-    result satisfies Record<"x" | "y", string>;
-    expect(result).toMatchInlineSnapshot(`
-      {
-        "x": "x",
-        "y": "yy",
-      }
-    `);
+    {
+      const result = objectMapValues(o, (v, k) => k.repeat(v));
+      result satisfies Record<"x" | "y", string>;
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "x": "x",
+          "y": "yy",
+        }
+      `);
+    }
+    {
+      const result = objectMapKeys(o, (v) => (v === 1 ? "w" : "z"));
+      result satisfies Record<"z" | "w", number>;
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "w": 1,
+          "z": 2,
+        }
+      `);
+    }
   });
 
   it("optional", () => {
@@ -442,35 +453,30 @@ describe(objectMapValues, () => {
       x: 3,
       z: undefined,
     };
-    const result = objectMapValues2(o, (v, k) => (v ? k.repeat(v) : "bad"));
-    result satisfies {
-      x: string;
-      y?: string;
-      z?: string;
-    };
-    expect(result).toMatchInlineSnapshot(`
-      {
-        "x": "xxx",
-        "z": "bad",
-      }
-    `);
-  });
-});
-
-describe(objectMapKeys, () => {
-  it("basic", () => {
-    const o = {
-      x: 1,
-      y: 2,
-    };
-    const result = objectMapKeys(o, (v) => (v === 1 ? "w" : "z"));
-    result satisfies Record<"z" | "w", number>;
-    expect(result).toMatchInlineSnapshot(`
-      {
-        "w": 1,
-        "z": 2,
-      }
-    `);
+    {
+      const result = objectMapValues(o, (v, k) => (v ? k.repeat(v) : "bad-v"));
+      result satisfies {
+        x: string;
+        y?: string;
+        z?: string;
+      };
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "x": "xxx",
+          "z": "bad-v",
+        }
+      `);
+    }
+    {
+      const result = objectMapKeys(o, (v, k) => (v ? k.repeat(v) : "bad-k"));
+      result satisfies Partial<Record<string, number>>;
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "bad-k": undefined,
+          "xxx": 3,
+        }
+      `);
+    }
   });
 });
 

--- a/packages/utils/src/lodash.ts
+++ b/packages/utils/src/lodash.ts
@@ -319,6 +319,13 @@ export function objectMapValues<K extends PropertyKey, V, V2>(
   return objectMapEntries(o, ([k, v]) => [k, f(v, k)]);
 }
 
+export function objectMapValues2<T extends object, V>(
+  o: T,
+  f: (v: T[keyof T], k: keyof T) => V
+): { [K in keyof T]: V } {
+  return objectMapEntries(o, ([k, v]) => [k, f(v, k)]) as any;
+}
+
 export function objectMapKeys<K extends PropertyKey, V, K2 extends PropertyKey>(
   o: Record<K, V>,
   f: (v: V, k: K) => K2

--- a/packages/utils/src/lodash.ts
+++ b/packages/utils/src/lodash.ts
@@ -293,43 +293,35 @@ export function objectKeys<T extends object>(o: T): (keyof T)[] {
   return Object.keys(o) as any;
 }
 
-export function objectEntries<T extends object>(
-  o: T
-): { [K in keyof T]: [K, T[K]] }[keyof T][] {
+export function objectEntries<T extends object>(o: T): ObjectEntry<T>[] {
   return Object.entries(o) as any;
 }
+
+type ObjectEntry<T extends object> = { [K in keyof T]: [K, T[K]] }[keyof T];
 
 export function objectFromEntries<K extends PropertyKey, V>(
   kvs: [K, V][]
 ): Record<K, V> {
   return Object.fromEntries(kvs) as any;
 }
-
-function objectMapEntries<K extends PropertyKey, V, K2 extends PropertyKey, V2>(
-  o: Record<K, V>,
-  f: (kv: [k: K, v: V]) => [K2, V2]
+function objectMapEntries<T extends object, K2 extends PropertyKey, V2>(
+  o: T,
+  f: (kv: ObjectEntry<T>) => [K2, V2]
 ): Record<K2, V2> {
   return objectFromEntries(objectEntries(o).map((kv) => f(kv)));
 }
 
-export function objectMapValues<K extends PropertyKey, V, V2>(
-  o: Record<K, V>,
-  f: (v: V, k: K) => V2
-): Record<K, V2> {
+export function objectMapValues<T extends object, V>(
+  o: T,
+  f: (v: T[keyof T], k: keyof T) => V
+): Record<keyof T, V> {
   return objectMapEntries(o, ([k, v]) => [k, f(v, k)]);
 }
 
-export function objectMapValues2<T extends object, V>(
+export function objectMapKeys<T extends object, K extends PropertyKey>(
   o: T,
-  f: (v: T[keyof T], k: keyof T) => V
-): { [K in keyof T]: V } {
-  return objectMapEntries(o, ([k, v]) => [k, f(v, k)]) as any;
-}
-
-export function objectMapKeys<K extends PropertyKey, V, K2 extends PropertyKey>(
-  o: Record<K, V>,
-  f: (v: V, k: K) => K2
-): Record<K2, V> {
+  f: (v: T[keyof T], k: keyof T) => K
+): Record<K, T[keyof T]> {
   return objectMapEntries(o, ([k, v]) => [f(v, k), v]);
 }
 


### PR DESCRIPTION
I noticed when trying to do the following in

- https://github.com/hi-ogawa/unocss-preset-antd/pull/52

```ts
interface SomeProps {
  enterFrom?: string
  enterTo?: string
  entered?: string
  // ...
}

const props: SomeProps = {};
objectMapValues(props, (v) => ...); // <--- type errror
```


Typing manipulation is getting wizardly (in a bad sense), but just hope we won't go that far.