### PR TITLE
feat(tiny-rpc)!: relax routes typing

### DIFF
--- a/.changeset/rotten-peas-compare.md
+++ b/.changeset/rotten-peas-compare.md
@@ -2,4 +2,4 @@
 "@hiogawa/tiny-rpc": major
 ---
 
-feat: relax routes typing
+feat!: relax routes typing

--- a/.changeset/rotten-peas-compare.md
+++ b/.changeset/rotten-peas-compare.md
@@ -1,0 +1,5 @@
+---
+"@hiogawa/tiny-rpc": major
+---
+
+feat: relax routes typing

--- a/packages/tiny-rpc/README.md
+++ b/packages/tiny-rpc/README.md
@@ -21,6 +21,7 @@ As `comlink` alternative:
 
 ## examples
 
+- https://github.com/hi-ogawa/toy-metronome/tree/ff0a853eb693b583167c86670be06e4cc3b6449c/src/audioworklet
 - https://github.com/hi-ogawa/argon2-wasm-bindgen/tree/650cc380689074be3574e3166178d76763f169cd/packages/app/src/argon2
 - https://github.com/hi-ogawa/ytsub-v3/tree/c4cf2b220ca317dbbd63cf7d8fa5725c32d5d4f9/app/trpc
 - https://github.com/hi-ogawa/youtube-dl-web-v2/tree/f187548ddebbf4aa67a9552b57ccc511b113e6cf/packages/app/src/trpc

--- a/packages/tiny-rpc/README.md
+++ b/packages/tiny-rpc/README.md
@@ -18,3 +18,9 @@ As `comlink` alternative:
 - https://github.com/antfu/birpc
 - https://github.com/GoogleChromeLabs/comlink/
 - https://github.com/brillout/telefunc
+
+## examples
+
+- https://github.com/hi-ogawa/argon2-wasm-bindgen/tree/650cc380689074be3574e3166178d76763f169cd/packages/app/src/argon2
+- https://github.com/hi-ogawa/ytsub-v3/tree/c4cf2b220ca317dbbd63cf7d8fa5725c32d5d4f9/app/trpc
+- https://github.com/hi-ogawa/youtube-dl-web-v2/tree/f187548ddebbf4aa67a9552b57ccc511b113e6cf/packages/app/src/trpc

--- a/packages/tiny-rpc/package.json
+++ b/packages/tiny-rpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/tiny-rpc",
-  "version": "0.2.3-pre.10",
+  "version": "0.2.3-pre.11",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/tiny-rpc/src/adapter-http.test.ts
+++ b/packages/tiny-rpc/src/adapter-http.test.ts
@@ -4,12 +4,7 @@ import { tinyassert } from "@hiogawa/utils";
 import { describe, expect, it, vi } from "vitest";
 import { ZodError, z } from "zod";
 import { httpClientAdapter, httpServerAdapter } from "./adapter-http";
-import {
-  TinyRpcError,
-  type TinyRpcRoutes,
-  exposeTinyRpc,
-  proxyTinyRpc,
-} from "./core";
+import { TinyRpcError, exposeTinyRpc, proxyTinyRpc } from "./core";
 import { defineTestRpcRoutes } from "./tests/helper";
 import { validateFn } from "./validation";
 
@@ -204,7 +199,7 @@ describe("adapter-http", () => {
     const routes = {
       identity: (v: any) => v,
       validate: validateFn(z.number().int())((x) => 2 * x),
-    } satisfies TinyRpcRoutes;
+    };
 
     const testObject = {
       date: new Date("2023-08-17"),

--- a/packages/tiny-rpc/src/core.ts
+++ b/packages/tiny-rpc/src/core.ts
@@ -4,6 +4,8 @@ import { objectHas, tinyassert } from "@hiogawa/utils";
 // it can expose and proxy all methods as async functions
 //
 
+// TODO: support "no-reply" call?
+
 export type TinyRpcProxy<R> = {
   [K in keyof R]: R[K] extends (...args: any[]) => any
     ? ToAsyncFn<R[K]>

--- a/packages/tiny-rpc/src/core.ts
+++ b/packages/tiny-rpc/src/core.ts
@@ -36,7 +36,7 @@ export function exposeTinyRpc<T>({
   return adapter.register(async ({ path, args }) => {
     const fn = routes[path];
     tinyassert(fn, new TinyRpcError("invalid path", { cause: path }));
-    return await fn(...args);
+    return fn.apply(routes, args);
   });
 }
 

--- a/packages/tiny-rpc/src/tests/helper.ts
+++ b/packages/tiny-rpc/src/tests/helper.ts
@@ -2,7 +2,6 @@ import { AsyncLocalStorage } from "node:async_hooks";
 import { type RequestHandler } from "@hattip/compose";
 import { tinyassert } from "@hiogawa/utils";
 import { z } from "zod";
-import type { TinyRpcRoutes } from "../core";
 import { validateFn } from "../validation";
 
 export function defineTestRpcRoutes() {
@@ -63,7 +62,7 @@ export function defineTestRpcRoutes() {
       const { request } = useContext();
       return request.headers.get("x-auth") === "good";
     },
-  } satisfies TinyRpcRoutes;
+  };
 
   return { routes, contextProviderHandler };
 }


### PR DESCRIPTION
- used for https://github.com/hi-ogawa/toy-metronome/pull/22

```ts
    exposeTinyRpc({
      routes: this,         // <---------- this pattern
      adapter: messagePortServerAdapter({
        port: this.port,
      }),
    });
```

This pattern was allowed for comlink, so let's mimic that. Having `routes: unknown` is not a big deal as long as proxy-side typing `TinyRpcProxy` can filter out properly and users can understand.
