### PR TITLE
feat: create `tiny-store` package

### DIFF
--- a/packages/tiny-store/README.md
+++ b/packages/tiny-store/README.md
@@ -1,0 +1,3 @@
+# tiny-store
+
+Simple platform-agnostic global state utility with trivial react integration via [`useSyncExternalStore`](https://react.dev/reference/react/useSyncExternalStore).

--- a/packages/tiny-store/package.json
+++ b/packages/tiny-store/package.json
@@ -28,7 +28,10 @@
   },
   "devDependencies": {
     "@hiogawa/utils": "workspace:*",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/user-event": "^14.4.3",
     "@types/react": "^18.2.14",
+    "@vitejs/plugin-react": "^4.0.1",
     "react": "^18.2.0"
   },
   "peerDependencies": {

--- a/packages/tiny-store/package.json
+++ b/packages/tiny-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/tiny-store",
-  "version": "0.0.1-pre.0",
+  "version": "0.0.1-pre.1",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/tiny-store/package.json
+++ b/packages/tiny-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/tiny-store",
-  "version": "0.0.0",
+  "version": "0.0.1-pre.0",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/tiny-store/package.json
+++ b/packages/tiny-store/package.json
@@ -10,6 +10,11 @@
       "import": "./dist/index.js",
       "require": "./dist/index.cjs",
       "types": "./dist/index.d.ts"
+    },
+    "./dist/react": {
+      "import": "./dist/react.js",
+      "require": "./dist/react.cjs",
+      "types": "./dist/react.d.ts"
     }
   },
   "files": [

--- a/packages/tiny-store/package.json
+++ b/packages/tiny-store/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@hiogawa/tiny-store",
+  "version": "0.0.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/hi-ogawa/js-utils",
+    "directory": "packages/tiny-store"
+  },
+  "scripts": {
+    "build": "tsup",
+    "test": "vitest",
+    "release": "pnpm publish --no-git-checks --access public"
+  },
+  "devDependencies": {
+    "@hiogawa/utils": "workspace:*",
+    "@types/react": "^18.2.14",
+    "react": "^18.2.0"
+  },
+  "peerDependencies": {
+    "react": "^18.0.0"
+  },
+  "peerDependenciesMeta": {
+    "react": {
+      "optional": true
+    }
+  }
+}

--- a/packages/tiny-store/src/core.test.ts
+++ b/packages/tiny-store/src/core.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
-import { createSimpleStore, storeSelect, storeTransform } from "./core";
+import { createTinyStore, tinyStoreSelect, tinyStoreTransform } from "./core";
 
-describe(createSimpleStore, () => {
+describe(createTinyStore, () => {
   it("basic", () => {
-    const store = createSimpleStore(0);
+    const store = createTinyStore(0);
     const onStoreChangeFn = vi.fn();
     const unsubscribe = store.subscribe(onStoreChangeFn);
 
@@ -21,10 +21,10 @@ describe(createSimpleStore, () => {
   });
 });
 
-describe(storeTransform, () => {
+describe(tinyStoreTransform, () => {
   it("basic", () => {
-    const store1 = createSimpleStore("0");
-    const store2 = storeTransform<string, number>(
+    const store1 = createTinyStore("0");
+    const store2 = tinyStoreTransform<string, number>(
       store1,
       JSON.parse,
       JSON.stringify
@@ -68,8 +68,8 @@ describe(storeTransform, () => {
   });
 
   it("memoized", () => {
-    const store = storeTransform<string, { x: number }>(
-      createSimpleStore(JSON.stringify({ x: 0 })),
+    const store = tinyStoreTransform<string, { x: number }>(
+      createTinyStore(JSON.stringify({ x: 0 })),
       JSON.parse,
       JSON.stringify
     );
@@ -100,9 +100,9 @@ describe(storeTransform, () => {
   });
 });
 
-describe(storeSelect, () => {
+describe(tinyStoreSelect, () => {
   it("basic", () => {
-    const store1 = createSimpleStore({
+    const store1 = createTinyStore({
       name: {
         first: "Jane",
         last: "Doe",
@@ -113,10 +113,10 @@ describe(storeSelect, () => {
         day: 1,
       },
     });
-    const store2 = storeSelect(store1, (v) => v.name);
+    const store2 = tinyStoreSelect(store1, (v) => v.name);
     store2.set satisfies null;
 
-    const store3 = storeSelect(store2, (v) => v.first);
+    const store3 = tinyStoreSelect(store2, (v) => v.first);
     store3.set satisfies null;
 
     const snapshots = [store2.get()];

--- a/packages/tiny-store/src/core.test.ts
+++ b/packages/tiny-store/src/core.test.ts
@@ -119,6 +119,10 @@ describe(storeSelect, () => {
       },
     });
     const store2 = storeSelect(store1, (v) => v.name);
+    store2.set satisfies null;
+
+    const store3 = storeSelect(store2, (v) => v.first);
+    store3.set satisfies null;
 
     const snapshots = [store2.get()];
     expect(snapshots.at(-1)).toMatchInlineSnapshot(`
@@ -127,6 +131,7 @@ describe(storeSelect, () => {
         "last": "Doe",
       }
     `);
+    expect(store3.get()).toMatchInlineSnapshot('"Jane"');
 
     store1.set((v) => ({ ...v, birth: { ...v.birth, day: 2 } }));
     snapshots.push(store2.get());
@@ -158,10 +163,8 @@ describe(storeSelect, () => {
         "last": "Doe",
       }
     `);
+    expect(store3.get()).toMatchInlineSnapshot('"John"');
     expect(snapshots[0]).not.toBe(snapshots.at(-1));
     expect(snapshots[0]).not.toEqual(snapshots.at(-1));
-
-    // @ts-expect-error not assignable to never
-    () => store2.set(snapshots[0]);
   });
 });

--- a/packages/tiny-store/src/core.test.ts
+++ b/packages/tiny-store/src/core.test.ts
@@ -1,12 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
-import {
-  SimpleStoreBase,
-  createSimpleStore,
-  storeSelect,
-  storeTransform,
-} from "./core";
+import { createSimpleStore, storeSelect, storeTransform } from "./core";
 
-describe(SimpleStoreBase, () => {
+describe(createSimpleStore, () => {
   it("basic", () => {
     const store = createSimpleStore(0);
     const onStoreChangeFn = vi.fn();

--- a/packages/tiny-store/src/core.test.ts
+++ b/packages/tiny-store/src/core.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  SimpleStoreBase,
+  createSimpleStore,
+  storeSelect,
+  storeTransform,
+} from "./core";
+
+describe(SimpleStoreBase, () => {
+  it("basic", () => {
+    const store = createSimpleStore(0);
+    const onStoreChangeFn = vi.fn();
+    const unsubscribe = store.subscribe(onStoreChangeFn);
+
+    expect(store.get()).toMatchInlineSnapshot("0");
+    expect(onStoreChangeFn.mock.calls.length).toMatchInlineSnapshot("0");
+
+    store.set(1);
+    expect(store.get()).toMatchInlineSnapshot("1");
+    expect(onStoreChangeFn.mock.calls.length).toMatchInlineSnapshot("1");
+
+    unsubscribe();
+    store.set((x) => x + 1);
+    expect(store.get()).toMatchInlineSnapshot("2");
+    expect(onStoreChangeFn.mock.calls.length).toMatchInlineSnapshot("1");
+  });
+});
+
+describe(storeTransform, () => {
+  it("basic", () => {
+    const store1 = createSimpleStore("0");
+    const store2 = storeTransform<string, number>(
+      store1,
+      JSON.parse,
+      JSON.stringify
+    );
+
+    const onStoreChangeFn1 = vi.fn();
+    const unsubscribe1 = store1.subscribe(onStoreChangeFn1);
+    const onStoreChangeFn2 = vi.fn();
+    const unsubscribe2 = store2.subscribe(onStoreChangeFn2);
+
+    expect(store1.get()).toMatchInlineSnapshot('"0"');
+    expect(store2.get()).toMatchInlineSnapshot("0");
+    expect(onStoreChangeFn1.mock.calls.length).toMatchInlineSnapshot("0");
+    expect(onStoreChangeFn2.mock.calls.length).toMatchInlineSnapshot("0");
+
+    store2.set(1);
+    expect(store1.get()).toMatchInlineSnapshot('"1"');
+    expect(store2.get()).toMatchInlineSnapshot("1");
+    expect(onStoreChangeFn1.mock.calls.length).toMatchInlineSnapshot("1");
+    expect(onStoreChangeFn2.mock.calls.length).toMatchInlineSnapshot("1");
+
+    store1.set("2");
+    expect(store1.get()).toMatchInlineSnapshot('"2"');
+    expect(store2.get()).toMatchInlineSnapshot("2");
+    expect(onStoreChangeFn1.mock.calls.length).toMatchInlineSnapshot("2");
+    expect(onStoreChangeFn2.mock.calls.length).toMatchInlineSnapshot("2");
+
+    unsubscribe2();
+    store2.set((x) => x + 1);
+    expect(store1.get()).toMatchInlineSnapshot('"3"');
+    expect(store2.get()).toMatchInlineSnapshot("3");
+    expect(onStoreChangeFn1.mock.calls.length).toMatchInlineSnapshot("3");
+    expect(onStoreChangeFn2.mock.calls.length).toMatchInlineSnapshot("2");
+
+    unsubscribe1();
+    store1.set((x) => x.repeat(2));
+    expect(store1.get()).toMatchInlineSnapshot('"33"');
+    expect(store2.get()).toMatchInlineSnapshot("33");
+    expect(onStoreChangeFn1.mock.calls.length).toMatchInlineSnapshot("3");
+    expect(onStoreChangeFn2.mock.calls.length).toMatchInlineSnapshot("2");
+  });
+
+  it("memoized", () => {
+    const store = storeTransform<string, { x: number }>(
+      createSimpleStore(JSON.stringify({ x: 0 })),
+      JSON.parse,
+      JSON.stringify
+    );
+
+    const res = [store.get()];
+    expect(res[0]).toMatchInlineSnapshot(`
+      {
+        "x": 0,
+      }
+    `);
+    res.push(store.get());
+    expect(res[0]).toEqual(res.at(-1));
+    expect(res[0]).toBe(res.at(-1));
+
+    store.set({ x: 0 }); // TODO: next `get` won't return new instance due to `decodeMemo`, which might be unintuitive
+    res.push(store.get());
+    expect(res[0]).toEqual(res.at(-1));
+    expect(res[0]).toBe(res.at(-1));
+
+    store.set({ x: 1 });
+    res.push(store.get());
+    expect(res.at(-1)).toMatchInlineSnapshot(`
+      {
+        "x": 1,
+      }
+    `);
+    expect(res.at(-1)).toBe(store.get());
+  });
+});
+
+describe(storeSelect, () => {
+  it("basic", () => {
+    const store1 = createSimpleStore({
+      name: {
+        first: "Jane",
+        last: "Doe",
+      },
+      birth: {
+        year: 2000,
+        month: 1,
+        day: 1,
+      },
+    });
+    const store2 = storeSelect(store1, (v) => v.name);
+
+    const snapshots = [store2.get()];
+    expect(snapshots.at(-1)).toMatchInlineSnapshot(`
+      {
+        "first": "Jane",
+        "last": "Doe",
+      }
+    `);
+
+    store1.set((v) => ({ ...v, birth: { ...v.birth, day: 2 } }));
+    snapshots.push(store2.get());
+    expect(snapshots.at(-1)).toMatchInlineSnapshot(`
+      {
+        "first": "Jane",
+        "last": "Doe",
+      }
+    `);
+    expect(snapshots[0]).toBe(snapshots.at(-1));
+    expect(snapshots[0]).toEqual(snapshots.at(-1));
+
+    store1.set((v) => ({ ...v, name: { ...v.name } }));
+    snapshots.push(store2.get());
+    expect(snapshots.at(-1)).toMatchInlineSnapshot(`
+      {
+        "first": "Jane",
+        "last": "Doe",
+      }
+    `);
+    expect(snapshots[0]).not.toBe(snapshots.at(-1));
+    expect(snapshots[0]).toEqual(snapshots.at(-1));
+
+    store1.set((v) => ({ ...v, name: { ...v.name, first: "John" } }));
+    snapshots.push(store2.get());
+    expect(snapshots.at(-1)).toMatchInlineSnapshot(`
+      {
+        "first": "John",
+        "last": "Doe",
+      }
+    `);
+    expect(snapshots[0]).not.toBe(snapshots.at(-1));
+    expect(snapshots[0]).not.toEqual(snapshots.at(-1));
+
+    // @ts-expect-error not assignable to never
+    () => store2.set(snapshots[0]);
+  });
+});

--- a/packages/tiny-store/src/core.ts
+++ b/packages/tiny-store/src/core.ts
@@ -2,9 +2,9 @@
 // platform agnostic store api
 //
 
-export interface SimpleStore<TGet, TSet = TGet> {
-  get: () => TGet;
-  set: (newValue: SetAction<TSet>) => void;
+export interface SimpleStore<T, IsReadonly extends boolean = false> {
+  get: () => T;
+  set: IsReadonly extends true ? null : (newValue: SetAction<T>) => void;
   subscribe: (onStoreChange: () => void) => () => void;
 }
 
@@ -31,15 +31,15 @@ export function storeTransform<T1, T2>(
 
 // transform readonly (for memoized selection)
 export function storeSelect<T1, T2>(
-  store: Omit<SimpleStore<T1, unknown>, "set">,
+  store: Omit<SimpleStore<T1>, "set">,
   decode: (v: T1) => T2
-): SimpleStore<T2, never> {
+): SimpleStore<T2, true> {
   // `subscribe` based on original store, but as long as `get` returns memoized value,
   // `useSyncExternalStore` won't cause re-rendering
   const decodeMemo = memoizeOne(decode);
   return {
     get: () => decodeMemo(store.get()),
-    set: () => {},
+    set: null,
     subscribe: store.subscribe,
   };
 }

--- a/packages/tiny-store/src/core.ts
+++ b/packages/tiny-store/src/core.ts
@@ -1,0 +1,166 @@
+//
+// platform agnostic store api
+//
+
+export interface SimpleStore<TGet, TSet = TGet> {
+  get: () => TGet;
+  set: (newValue: SetAction<TSet>) => void;
+  subscribe: (onStoreChange: () => void) => () => void;
+}
+
+//
+// transform
+//
+
+// transform read/write (e.g. for JSON.parse/stringify based local storage)
+export function storeTransform<T1, T2>(
+  store: SimpleStore<T1>,
+  decode: (v1: T1) => T2,
+  encode: (v2: T2) => T1
+): SimpleStore<T2> {
+  const decodeMemo = memoizeOne(decode);
+  return {
+    get: () => decodeMemo(store.get()),
+    set: (v2) => {
+      // TODO: invalidate cache so that next `get` will see fresh data?
+      store.set((v1) => encode(applyAction(() => decodeMemo(v1), v2)));
+    },
+    subscribe: store.subscribe,
+  };
+}
+
+// transform readonly (for memoized selection)
+export function storeSelect<T1, T2>(
+  store: Omit<SimpleStore<T1, unknown>, "set">,
+  decode: (v: T1) => T2
+): SimpleStore<T2, never> {
+  // `subscribe` based on original store, but as long as `get` returns memoized value,
+  // `useSyncExternalStore` won't cause re-rendering
+  const decodeMemo = memoizeOne(decode);
+  return {
+    get: () => decodeMemo(store.get()),
+    set: () => {},
+    subscribe: store.subscribe,
+  };
+}
+
+// make result stable if the input is same as last (i.e. memoize with cache size 1)
+function memoizeOne<F extends (arg: any) => any>(f: F): F {
+  let last: { k: any; v: any } | undefined;
+  return function wrapper(arg: any) {
+    if (!last || last.k !== arg) {
+      last = { k: arg, v: f(arg) };
+    }
+    return last.v;
+  } as any;
+}
+
+//
+// basic factory
+//
+
+export function createSimpleStore<T>(defaultValue: T): SimpleStore<T> {
+  return new SimpleStoreBase(new MemoryAdapter<T>(defaultValue));
+}
+
+// ssr fallbacks to `defaultValue` which can cause hydration mismatch
+export function createSimpleStoreWithLocalStorage<T>(
+  key: string,
+  defaultValue: T,
+  parse = JSON.parse,
+  stringify = JSON.stringify
+): SimpleStore<T> {
+  return storeTransform<string | null, T>(
+    new SimpleStoreBase(new LocalStorageAdapter(key)),
+    (s: string | null): T => (s === null ? defaultValue : parse(s)),
+    (t: T): string | null => stringify(t)
+  );
+}
+
+//
+// base store implementation
+//
+
+export class SimpleStoreBase<T> implements SimpleStore<T> {
+  private listeners = new Set<() => void>();
+
+  constructor(private adapter: SimpleStoreAdapter<T>) {}
+
+  get = () => this.adapter.get();
+
+  set = (action: SetAction<T>) => {
+    this.adapter.set(applyAction(this.get, action));
+    this.notify();
+  };
+
+  subscribe = (listener: () => void) => {
+    this.listeners.add(listener);
+    const unsubscribeAdapter = this.adapter.subscribe?.(listener);
+    return () => {
+      unsubscribeAdapter?.();
+      this.listeners.delete(listener);
+    };
+  };
+
+  protected notify = () => {
+    this.listeners.forEach((l) => l());
+  };
+}
+
+type SetAction<T> = T | ((prev: T) => T);
+
+function applyAction<T>(v: () => T, action: SetAction<T>): T {
+  // it cannot narrow enough since `T` itself could be a function
+  return typeof action === "function" ? (action as any)(v()) : action;
+}
+
+//
+// abstract adapter to naturally support LocalStorage
+//
+
+interface SimpleStoreAdapter<T> {
+  get: () => T;
+  set: (value: T) => void;
+  subscribe?: (onStoreChange: () => void) => () => void;
+}
+
+class MemoryAdapter<T> implements SimpleStoreAdapter<T> {
+  constructor(private value: T) {}
+  get = () => this.value;
+  set = (value: T) => (this.value = value);
+}
+
+class LocalStorageAdapter implements SimpleStoreAdapter<string | null> {
+  constructor(private key: string) {}
+
+  get() {
+    if (typeof window === "undefined") {
+      return null;
+    }
+    return window.localStorage.getItem(this.key);
+  }
+
+  set(value: string | null) {
+    if (value === null) {
+      window.localStorage.removeItem(this.key);
+    } else {
+      window.localStorage.setItem(this.key, value);
+    }
+  }
+
+  subscribe = (listener: () => void) => {
+    if (typeof window === "undefined") {
+      return () => {};
+    }
+    const handler = (e: StorageEvent) => {
+      // key is null when localStorage.clear
+      if (e.key === this.key || e.key === null) {
+        listener();
+      }
+    };
+    window.addEventListener("storage", handler);
+    return () => {
+      window.removeEventListener("storage", handler);
+    };
+  };
+}

--- a/packages/tiny-store/src/core.ts
+++ b/packages/tiny-store/src/core.ts
@@ -148,6 +148,7 @@ class LocalStorageAdapter implements SimpleStoreAdapter<string | null> {
     }
   }
 
+  // TODO: this will register event listener for each observer of each store, which might be excessive.
   subscribe = (listener: () => void) => {
     if (typeof window === "undefined") {
       return () => {};

--- a/packages/tiny-store/src/index.ts
+++ b/packages/tiny-store/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./core";
+export * from "./local-storage";

--- a/packages/tiny-store/src/local-storage.ts
+++ b/packages/tiny-store/src/local-storage.ts
@@ -1,25 +1,25 @@
 import {
-  type SimpleStore,
-  type SimpleStoreAdapter,
-  SimpleStoreBase,
-  storeTransform,
+  TinyStore,
+  type TinyStoreAdapter,
+  type TinyStoreApi,
+  tinyStoreTransform,
 } from "./core";
 
 // ssr fallbacks to `defaultValue` which can cause hydration mismatch
-export function createSimpleStoreWithLocalStorage<T>(
+export function createTinyStoreWithStorage<T>(
   key: string,
   defaultValue: T,
   parse = JSON.parse,
   stringify = JSON.stringify
-): SimpleStore<T> {
-  return storeTransform<string | null, T>(
-    new SimpleStoreBase(new LocalStorageAdapter(key)),
+): TinyStoreApi<T> {
+  return tinyStoreTransform<string | null, T>(
+    new TinyStore(new TinyScoreLocalStorageAdapter(key)),
     (s: string | null): T => (s === null ? defaultValue : parse(s)),
     (t: T): string | null => stringify(t)
   );
 }
 
-class LocalStorageAdapter implements SimpleStoreAdapter<string | null> {
+class TinyScoreLocalStorageAdapter implements TinyStoreAdapter<string | null> {
   constructor(private key: string) {}
 
   get() {

--- a/packages/tiny-store/src/local-storage.ts
+++ b/packages/tiny-store/src/local-storage.ts
@@ -1,0 +1,56 @@
+import {
+  type SimpleStore,
+  type SimpleStoreAdapter,
+  SimpleStoreBase,
+  storeTransform,
+} from "./core";
+
+// ssr fallbacks to `defaultValue` which can cause hydration mismatch
+export function createSimpleStoreWithLocalStorage<T>(
+  key: string,
+  defaultValue: T,
+  parse = JSON.parse,
+  stringify = JSON.stringify
+): SimpleStore<T> {
+  return storeTransform<string | null, T>(
+    new SimpleStoreBase(new LocalStorageAdapter(key)),
+    (s: string | null): T => (s === null ? defaultValue : parse(s)),
+    (t: T): string | null => stringify(t)
+  );
+}
+
+class LocalStorageAdapter implements SimpleStoreAdapter<string | null> {
+  constructor(private key: string) {}
+
+  get() {
+    if (typeof window === "undefined") {
+      return null;
+    }
+    return window.localStorage.getItem(this.key);
+  }
+
+  set(value: string | null) {
+    if (value === null) {
+      window.localStorage.removeItem(this.key);
+    } else {
+      window.localStorage.setItem(this.key, value);
+    }
+  }
+
+  // TODO: this will register event listener for each observer of each store, which might be excessive.
+  subscribe = (listener: () => void) => {
+    if (typeof window === "undefined") {
+      return () => {};
+    }
+    const handler = (e: StorageEvent) => {
+      // key is null when localStorage.clear
+      if (e.key === this.key || e.key === null) {
+        listener();
+      }
+    };
+    window.addEventListener("storage", handler);
+    return () => {
+      window.removeEventListener("storage", handler);
+    };
+  };
+}

--- a/packages/tiny-store/src/react.test.tsx
+++ b/packages/tiny-store/src/react.test.tsx
@@ -4,7 +4,7 @@ import React from "react";
 import { describe, expect, it } from "vitest";
 import { createTinyStore, tinyStoreSelect } from "./core";
 import { createTinyStoreWithStorage } from "./local-storage";
-import { useTinyStore } from "./react";
+import { useTinyStore, useTinyStoreStorage } from "./react";
 
 // cf. https://github.com/pmndrs/jotai/blob/2526039ea4da082749adc8a449c33422c53d9819/tests/react/basic.test.tsx
 
@@ -112,7 +112,10 @@ describe(useTinyStore, () => {
   });
 
   it(createTinyStoreWithStorage, async () => {
-    const store = createTinyStoreWithStorage("tiny-store:react.test", {
+    const KEY = "tiny-store:react.test";
+    window.localStorage.removeItem(KEY);
+
+    const store = createTinyStoreWithStorage(KEY, {
       x: 0,
     });
 
@@ -140,7 +143,7 @@ describe(useTinyStore, () => {
     //
     // recreate store and rener
     //
-    const store2 = createTinyStoreWithStorage("tiny-store:react.test", {
+    const store2 = createTinyStoreWithStorage(KEY, {
       x: 0,
     });
     cleanup();
@@ -151,6 +154,43 @@ describe(useTinyStore, () => {
     );
     expect(await getTestidText("demo")).toMatchInlineSnapshot('"{\\"x\\":1}"');
 
+    await userEvent.click(await screen.findByRole("button"));
+    expect(await getTestidText("demo")).toMatchInlineSnapshot('"{\\"x\\":2}"');
+  });
+
+  it(useTinyStoreStorage, async () => {
+    const KEY = "tiny-store:react.test";
+    window.localStorage.removeItem(KEY);
+
+    function Demo() {
+      const [state, setState] = useTinyStoreStorage(KEY, {
+        x: 0,
+      });
+      return (
+        <>
+          <div data-testid="demo">{JSON.stringify(state)}</div>
+          <button onClick={() => setState(({ x }) => ({ x: x + 1 }))}>
+            +1
+          </button>
+        </>
+      );
+    }
+    render(
+      <>
+        <Demo />
+      </>
+    );
+    expect(await getTestidText("demo")).toMatchInlineSnapshot('"{\\"x\\":0}"');
+    await userEvent.click(await screen.findByRole("button"));
+    expect(await getTestidText("demo")).toMatchInlineSnapshot('"{\\"x\\":1}"');
+
+    cleanup();
+    render(
+      <>
+        <Demo />
+      </>
+    );
+    expect(await getTestidText("demo")).toMatchInlineSnapshot('"{\\"x\\":1}"');
     await userEvent.click(await screen.findByRole("button"));
     expect(await getTestidText("demo")).toMatchInlineSnapshot('"{\\"x\\":2}"');
   });

--- a/packages/tiny-store/src/react.test.tsx
+++ b/packages/tiny-store/src/react.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import { createSimpleStore } from "./core";
+import { useSimpleStore } from "./react";
+
+// cf. https://github.com/pmndrs/jotai/blob/2526039ea4da082749adc8a449c33422c53d9819/tests/react/basic.test.tsx
+
+describe(useSimpleStore, () => {
+  it("basic", async () => {
+    const store = createSimpleStore(0);
+
+    function Demo() {
+      const [state, setState] = useSimpleStore(store);
+      return (
+        <>
+          <main>{state}</main>
+          <button onClick={() => setState((c) => c + 1)}>increment</button>
+        </>
+      );
+    }
+    render(<Demo />);
+    expect(await screen.findByRole("main")).toMatchInlineSnapshot(`
+      <main>
+        0
+      </main>
+    `);
+    await userEvent.click(await screen.findByRole("button"));
+    expect(await screen.findByRole("main")).toMatchInlineSnapshot(`
+      <main>
+        1
+      </main>
+    `);
+  });
+});

--- a/packages/tiny-store/src/react.test.tsx
+++ b/packages/tiny-store/src/react.test.tsx
@@ -2,17 +2,17 @@ import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
 import { describe, expect, it } from "vitest";
-import { createSimpleStore, storeSelect } from "./core";
-import { createSimpleStoreWithLocalStorage } from "./local-storage";
-import { useSimpleStore } from "./react";
+import { createTinyStore, tinyStoreSelect } from "./core";
+import { createTinyStoreWithStorage } from "./local-storage";
+import { useTinyStore } from "./react";
 
 // cf. https://github.com/pmndrs/jotai/blob/2526039ea4da082749adc8a449c33422c53d9819/tests/react/basic.test.tsx
 
-describe(useSimpleStore, () => {
+describe(useTinyStore, () => {
   it("basic", async () => {
-    const store = createSimpleStore(1);
+    const store = createTinyStore(1);
     function Demo() {
-      const [state, setState] = useSimpleStore(store);
+      const [state, setState] = useTinyStore(store);
       return (
         <>
           <div data-testid="demo">{state}</div>
@@ -31,8 +31,8 @@ describe(useSimpleStore, () => {
     expect(await getTestidText("demo")).toMatchInlineSnapshot('"2"');
   });
 
-  it(storeSelect, async () => {
-    const store1 = createSimpleStore({
+  it(tinyStoreSelect, async () => {
+    const store1 = createTinyStore({
       name: {
         first: "Jane",
       },
@@ -40,10 +40,10 @@ describe(useSimpleStore, () => {
         year: 2000,
       },
     });
-    const store2 = storeSelect(store1, (v) => v.name);
+    const store2 = tinyStoreSelect(store1, (v) => v.name);
 
     function Demo1() {
-      const [state, setState] = useSimpleStore(store1);
+      const [state, setState] = useTinyStore(store1);
       return (
         <>
           <div data-testid="demo1">
@@ -68,7 +68,7 @@ describe(useSimpleStore, () => {
     }
 
     function Demo2() {
-      const [state] = useSimpleStore(store2);
+      const [state] = useTinyStore(store2);
       return (
         <>
           <div data-testid="demo2">
@@ -111,13 +111,13 @@ describe(useSimpleStore, () => {
         `);
   });
 
-  it(createSimpleStoreWithLocalStorage, async () => {
-    const store = createSimpleStoreWithLocalStorage("tiny-store:react.test", {
+  it(createTinyStoreWithStorage, async () => {
+    const store = createTinyStoreWithStorage("tiny-store:react.test", {
       x: 0,
     });
 
     function Demo(props: { store: typeof store }) {
-      const [state, setState] = useSimpleStore(props.store);
+      const [state, setState] = useTinyStore(props.store);
       return (
         <>
           <div data-testid="demo">{JSON.stringify(state)}</div>
@@ -140,7 +140,7 @@ describe(useSimpleStore, () => {
     //
     // recreate store and rener
     //
-    const store2 = createSimpleStoreWithLocalStorage("tiny-store:react.test", {
+    const store2 = createTinyStoreWithStorage("tiny-store:react.test", {
       x: 0,
     });
     cleanup();

--- a/packages/tiny-store/src/react.test.tsx
+++ b/packages/tiny-store/src/react.test.tsx
@@ -1,35 +1,129 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import React from "react";
 import { describe, expect, it } from "vitest";
-import { createSimpleStore } from "./core";
+import { createSimpleStore, storeSelect } from "./core";
 import { useSimpleStore } from "./react";
 
 // cf. https://github.com/pmndrs/jotai/blob/2526039ea4da082749adc8a449c33422c53d9819/tests/react/basic.test.tsx
 
 describe(useSimpleStore, () => {
   it("basic", async () => {
-    const store = createSimpleStore(0);
-
+    const store = createSimpleStore(1);
     function Demo() {
       const [state, setState] = useSimpleStore(store);
       return (
         <>
-          <main>{state}</main>
-          <button onClick={() => setState((c) => c + 1)}>increment</button>
+          <div data-testid="demo">{state}</div>
+          <button onClick={() => setState((c) => c + 1)}>+1</button>
         </>
       );
     }
-    render(<Demo />);
-    expect(await screen.findByRole("main")).toMatchInlineSnapshot(`
-      <main>
-        0
-      </main>
-    `);
+    render(
+      <>
+        <Demo />
+      </>
+    );
+    expect(await getTestidText("demo")).toMatchInlineSnapshot('"1"');
+
     await userEvent.click(await screen.findByRole("button"));
-    expect(await screen.findByRole("main")).toMatchInlineSnapshot(`
-      <main>
-        1
-      </main>
-    `);
+    expect(await getTestidText("demo")).toMatchInlineSnapshot('"2"');
+  });
+
+  it(storeSelect, async () => {
+    const store1 = createSimpleStore({
+      name: {
+        first: "Jane",
+      },
+      birth: {
+        year: 2000,
+      },
+    });
+    const store2 = storeSelect(store1, (v) => v.name);
+
+    function Demo1() {
+      const [state, setState] = useSimpleStore(store1);
+      return (
+        <>
+          <div data-testid="demo1">
+            commit = {useCommitCount()}, state = {JSON.stringify(state)}
+          </div>
+          <button
+            data-testid="button-birth"
+            onClick={() =>
+              setState((v) => ({ ...v, birth: { year: v.birth.year + 1 } }))
+            }
+          >
+            +1
+          </button>
+          <button
+            data-testid="button-name"
+            onClick={() => setState((v) => ({ ...v, name: { first: "John" } }))}
+          >
+            John
+          </button>
+        </>
+      );
+    }
+
+    function Demo2() {
+      const [state] = useSimpleStore(store2);
+      return (
+        <>
+          <div data-testid="demo2">
+            commit = {useCommitCount()}, state = {JSON.stringify(state)}
+          </div>
+        </>
+      );
+    }
+
+    render(
+      <>
+        <Demo1 />
+        <Demo2 />
+      </>
+    );
+    expect([await getTestidText("demo1"), await getTestidText("demo2")])
+      .toMatchInlineSnapshot(`
+        [
+          "commit = 1, state = {\\"name\\":{\\"first\\":\\"Jane\\"},\\"birth\\":{\\"year\\":2000}}",
+          "commit = 1, state = {\\"first\\":\\"Jane\\"}",
+        ]
+      `);
+
+    await userEvent.click(await screen.findByTestId("button-birth"));
+    expect([await getTestidText("demo1"), await getTestidText("demo2")])
+      .toMatchInlineSnapshot(`
+        [
+          "commit = 2, state = {\\"name\\":{\\"first\\":\\"Jane\\"},\\"birth\\":{\\"year\\":2001}}",
+          "commit = 1, state = {\\"first\\":\\"Jane\\"}",
+        ]
+      `);
+
+    await userEvent.click(await screen.findByTestId("button-name"));
+    expect([await getTestidText("demo1"), await getTestidText("demo2")])
+      .toMatchInlineSnapshot(`
+          [
+            "commit = 3, state = {\\"name\\":{\\"first\\":\\"John\\"},\\"birth\\":{\\"year\\":2001}}",
+            "commit = 2, state = {\\"first\\":\\"John\\"}",
+          ]
+        `);
   });
 });
+
+//
+// helpers
+//
+
+async function getTestidText(testId: string) {
+  const el = await screen.findByTestId(testId);
+  return el.textContent;
+}
+
+function useCommitCount() {
+  const commitCountRef = React.useRef(1);
+  React.useEffect(() => {
+    commitCountRef.current += 1;
+  });
+  return commitCountRef.current;
+}

--- a/packages/tiny-store/src/react.test.tsx
+++ b/packages/tiny-store/src/react.test.tsx
@@ -2,11 +2,8 @@ import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
 import { describe, expect, it } from "vitest";
-import {
-  createSimpleStore,
-  createSimpleStoreWithLocalStorage,
-  storeSelect,
-} from "./core";
+import { createSimpleStore, storeSelect } from "./core";
+import { createSimpleStoreWithLocalStorage } from "./local-storage";
 import { useSimpleStore } from "./react";
 
 // cf. https://github.com/pmndrs/jotai/blob/2526039ea4da082749adc8a449c33422c53d9819/tests/react/basic.test.tsx

--- a/packages/tiny-store/src/react.ts
+++ b/packages/tiny-store/src/react.ts
@@ -1,8 +1,8 @@
 import React from "react";
-import type { SimpleStore } from "./core";
+import type { TinyStoreApi } from "./core";
 
-export function useSimpleStore<T, IsReadonly extends boolean>(
-  store: SimpleStore<T, IsReadonly>
+export function useTinyStore<T, IsReadonly extends boolean>(
+  store: TinyStoreApi<T, IsReadonly>
 ) {
   React.useSyncExternalStore(store.subscribe, store.get, store.get);
   return [store.get(), store.set] as const;

--- a/packages/tiny-store/src/react.ts
+++ b/packages/tiny-store/src/react.ts
@@ -1,7 +1,9 @@
 import React from "react";
 import type { SimpleStore } from "./core";
 
-export function useSimpleStore<TOut, TIn>(store: SimpleStore<TOut, TIn>) {
+export function useSimpleStore<T, IsReadonly extends boolean>(
+  store: SimpleStore<T, IsReadonly>
+) {
   React.useSyncExternalStore(store.subscribe, store.get, store.get);
   return [store.get(), store.set] as const;
 }

--- a/packages/tiny-store/src/react.ts
+++ b/packages/tiny-store/src/react.ts
@@ -1,0 +1,7 @@
+import React from "react";
+import type { SimpleStore } from "./core";
+
+export function useSimpleStore<TOut, TIn>(store: SimpleStore<TOut, TIn>) {
+  React.useSyncExternalStore(store.subscribe, store.get, store.get);
+  return [store.get(), store.set] as const;
+}

--- a/packages/tiny-store/src/react.ts
+++ b/packages/tiny-store/src/react.ts
@@ -1,9 +1,18 @@
 import React from "react";
 import type { TinyStoreApi } from "./core";
+import { createTinyStoreWithStorage } from "./local-storage";
 
 export function useTinyStore<T, IsReadonly extends boolean>(
   store: TinyStoreApi<T, IsReadonly>
 ) {
   React.useSyncExternalStore(store.subscribe, store.get, store.get);
   return [store.get(), store.set] as const;
+}
+
+export function useTinyLocalStorage<T>(key: string, defaultValue: T) {
+  const store = React.useMemo(
+    () => createTinyStoreWithStorage(key, defaultValue),
+    [key]
+  );
+  return useTinyStore(store);
 }

--- a/packages/tiny-store/src/react.ts
+++ b/packages/tiny-store/src/react.ts
@@ -9,7 +9,7 @@ export function useTinyStore<T, IsReadonly extends boolean>(
   return [store.get(), store.set] as const;
 }
 
-export function useTinyLocalStorage<T>(key: string, defaultValue: T) {
+export function useTinyStoreStorage<T>(key: string, defaultValue: T) {
   const store = React.useMemo(
     () => createTinyStoreWithStorage(key, defaultValue),
     [key]

--- a/packages/tiny-store/tsconfig.json
+++ b/packages/tiny-store/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src"]
+}

--- a/packages/tiny-store/tsconfig.json
+++ b/packages/tiny-store/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
-  "include": ["src"]
+  "include": ["src"],
+  "compilerOptions": {
+    "jsx": "preserve"
+  }
 }

--- a/packages/tiny-store/tsup.config.ts
+++ b/packages/tiny-store/tsup.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts", "src/react.ts"],
+  format: ["esm", "cjs"],
+  dts: true,
+  splitting: false,
+});

--- a/packages/tiny-store/vitest.config.ts
+++ b/packages/tiny-store/vitest.config.ts
@@ -4,11 +4,10 @@ import { defineConfig } from "vitest/config";
 // based on https://github.com/vitest-dev/vitest/blob/1fe8286c790cef9063b1f5f8147f6d41fc14bf79/examples/react-testing-lib/vite.config.ts
 
 export default defineConfig({
-  // @ts-ignore peed dep?
+  // @ts-ignore peer dep
   plugins: [react()],
   test: {
     globals: true,
     environment: "jsdom",
-    setupFiles: "./src/test/setup.ts",
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -253,6 +253,18 @@ importers:
         specifier: ^3.12.7
         version: 3.12.7
 
+  packages/tiny-store:
+    devDependencies:
+      '@hiogawa/utils':
+        specifier: workspace:*
+        version: link:../utils
+      '@types/react':
+        specifier: ^18.2.14
+        version: 18.2.14
+      react:
+        specifier: ^18.2.0
+        version: 18.2.0
+
   packages/utils: {}
 
   packages/utils-hattip: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -258,9 +258,18 @@ importers:
       '@hiogawa/utils':
         specifier: workspace:*
         version: link:../utils
+      '@testing-library/react':
+        specifier: ^14.0.0
+        version: 14.0.0(react-dom@18.2.0)(react@18.2.0)
+      '@testing-library/user-event':
+        specifier: ^14.4.3
+        version: 14.4.3(@testing-library/dom@9.3.1)
       '@types/react':
         specifier: ^18.2.14
         version: 18.2.14
+      '@vitejs/plugin-react':
+        specifier: ^4.0.1
+        version: 4.0.1(vite@4.4.7)
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -2683,14 +2692,6 @@ packages:
       clone: 1.0.4
     dev: true
 
-  /define-properties@1.1.4:
-    resolution: {integrity: sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      has-property-descriptors: 1.0.0
-      object-keys: 1.1.1
-    dev: true
-
   /define-properties@1.2.0:
     resolution: {integrity: sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==}
     engines: {node: '>= 0.4'}
@@ -4195,7 +4196,7 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.1.4
+      define-properties: 1.2.0
       has-symbols: 1.0.3
       object-keys: 1.1.1
     dev: true
@@ -4815,7 +4816,7 @@ packages:
     resolution: {integrity: sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==}
     dependencies:
       call-bind: 1.0.2
-      get-intrinsic: 1.2.0
+      get-intrinsic: 1.2.1
       object-inspect: 1.12.3
     dev: true
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,7 +35,13 @@
       "path": "packages/tiny-sql"
     },
     {
+      "path": "packages/tiny-sql/examples/postgresql"
+    },
+    {
       "path": "packages/tiny-sql/examples/sqlite"
+    },
+    {
+      "path": "packages/tiny-store"
     },
     {
       "path": "packages/utils"


### PR DESCRIPTION
Porting things back to utils as a dedicated package
- https://github.com/hi-ogawa/ytsub-v3/pull/499
- https://github.com/hi-ogawa/toy-metronome/pull/21

## todo

- [x] react test
- [x] local storage test
- [x] rename
- [x] dog-food
  - [x] https://github.com/hi-ogawa/ytsub-v3/pull/499
  - [x] https://github.com/hi-ogawa/toy-metronome/pull/27
