### PR TITLE
chore(utils): simplify `TinyAssertionError`

### DIFF
--- a/packages/utils/src/tinyassert.ts
+++ b/packages/utils/src/tinyassert.ts
@@ -18,9 +18,9 @@ export function tinyassert(
 export class TinyAssertionError extends Error {
   constructor(message?: string, stackStartFunction?: Function) {
     super(message);
-    if ("captureStackTrace" in Error) {
-      // @ts-ignore-error
-      Error.captureStackTrace(this, stackStartFunction ?? TinyAssertionError);
+    if (stackStartFunction && "captureStackTrace" in Error) {
+      // @ts-ignore
+      Error.captureStackTrace(this, stackStartFunction);
     }
   }
 }


### PR DESCRIPTION
Little cleanup since esbuild renames class when it's self-referencial, which makes `_TinyAssertionError` to appear in stack trace.

```tsx
// packages/utils/dist/index.js

//
// before
//
var TinyAssertionError = class _TinyAssertionError extends Error {
  constructor(message, stackStartFunction) {
    super(message);
    if ("captureStackTrace" in Error) {
      Error.captureStackTrace(this, stackStartFunction ?? _TinyAssertionError);
    }
  }
};

//
// after
//
var TinyAssertionError = class extends Error {
  constructor(message, stackStartFunction) {
    super(message);
    if (stackStartFunction && "captureStackTrace" in Error) {
      Error.captureStackTrace(this, stackStartFunction);
    }
  }
};
```