### PR TITLE
refactor(tiny-store): relax constness

### DIFF
--- a/packages/tiny-store/package.json
+++ b/packages/tiny-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/tiny-store",
-  "version": "0.0.1-pre.1",
+  "version": "0.0.1-pre.2",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/tiny-store/src/core.ts
+++ b/packages/tiny-store/src/core.ts
@@ -2,9 +2,9 @@
 // platform agnostic store api
 //
 
-export interface TinyStoreApi<T, IsReadonly extends boolean = false> {
+export interface TinyStoreApi<T, RO extends boolean = false> {
   get: () => T;
-  set: IsReadonly extends true ? null : (newValue: SetAction<T>) => void;
+  set: RO extends true ? null : (newValue: SetAction<T>) => void; // hide method when RO (readonly)
   subscribe: (onStoreChange: () => void) => () => void;
 }
 

--- a/packages/tiny-store/src/react.ts
+++ b/packages/tiny-store/src/react.ts
@@ -2,11 +2,11 @@ import React from "react";
 import type { TinyStoreApi } from "./core";
 import { createTinyStoreWithStorage } from "./local-storage";
 
-export function useTinyStore<T, IsReadonly extends boolean>(
-  store: TinyStoreApi<T, IsReadonly>
-) {
+export function useTinyStore<T, RO extends boolean>(
+  store: TinyStoreApi<T, RO>
+): [T, TinyStoreApi<T, RO>["set"]] {
   React.useSyncExternalStore(store.subscribe, store.get, store.get);
-  return [store.get(), store.set] as const;
+  return [store.get(), store.set];
 }
 
 export function useTinyStoreStorage<T>(key: string, defaultValue: T) {

--- a/packages/utils/src/misc.ts
+++ b/packages/utils/src/misc.ts
@@ -25,14 +25,14 @@ export function includesGuard<T>(ls: readonly T[], v: unknown): v is T {
   return ls.includes(v as T);
 }
 
-/** silence "error TSTS2322" but practically this is safer and more convenient than resorting to `any` */
+/** silence "error TSTS2322" but practically this is safer and more convenient than resorting to `any` in a random place */
 export function safeFunctionCast<F extends (...args: any[]) => any>(
   f: (...args: Parameters<F>) => ReturnType<F>
 ): F {
-  // silence type error:
+  // @ts-expect-error
   //   error TS2322: Type '(...args: Parameters<F>) => ReturnType<F>' is not assignable to type 'F'.
   //   '(...args: Parameters<F>) => ReturnType<F>' is assignable to the constraint of type 'F', but 'F' could be instantiated with a different subtype of constraint '(...args: any[]) => any'.
-  return f as any;
+  return f;
 }
 
 // helpers for easily paring addEventListener/removeEventListener where listener argument is inferred based on EventMap


### PR DESCRIPTION
Just spotted tiny papercut when writing `createTinyForm(useTinyStoreStorage(...))`