### PR TITLE
chore(sort-package-json): improve help

### DIFF
--- a/packages/sort-package-json/README.md
+++ b/packages/sort-package-json/README.md
@@ -30,3 +30,13 @@ Examples:
 ```
 
 <!-- %template-output-end:help% -->
+
+## development
+
+```sh
+pnpm i
+pnpm scrape
+pnpm build
+pnpm doc
+pnpm release
+```

--- a/packages/sort-package-json/README.md
+++ b/packages/sort-package-json/README.md
@@ -19,14 +19,14 @@ $ sort-package-json --help
 
 ```txt
 $ sort-package-json --help
-@hiogawa/sort-package-json@0.0.0
+@hiogawa/sort-package-json@0.0.1-pre.0
 
 Usage:
   sort-package-json [package.json files...]
 
 Example:
   # sort package.json files in pnpm workspace
-  sort-package-json $(pnpm ls --filter '*' --depth -1 --json | jq -r '.[] | .path' | xargs -i echo {}/package.json)
+  sort-package-json $(pnpm ls --filter '*' --depth -1 --json | jq -r '.[] | .path' | xargs -I '{}' echo '{}/package.json')
 ```
 
 <!-- %template-output-end:help% -->

--- a/packages/sort-package-json/README.md
+++ b/packages/sort-package-json/README.md
@@ -19,13 +19,13 @@ $ sort-package-json --help
 
 ```txt
 $ sort-package-json --help
-@hiogawa/sort-package-json@0.0.1-pre.0
+@hiogawa/sort-package-json@0.0.1
 
 Usage:
   sort-package-json [package.json files...]
 
-Example:
-  # sort package.json files in pnpm workspace
+Examples:
+  # Sort package.json files in pnpm workspace
   sort-package-json $(pnpm ls --filter '*' --depth -1 --json | jq -r '.[] | .path' | xargs -I '{}' echo '{}/package.json')
 ```
 

--- a/packages/sort-package-json/README.md
+++ b/packages/sort-package-json/README.md
@@ -22,7 +22,11 @@ $ sort-package-json --help
 @hiogawa/sort-package-json@0.0.0
 
 Usage:
-  $ sort-package-json [package.json files...]
+  sort-package-json [package.json files...]
+
+Example:
+  # sort package.json files in pnpm workspace
+  sort-package-json $(pnpm ls --filter '*' --depth -1 --json | jq -r '.[] | .path' | xargs -i echo {}/package.json)
 ```
 
 <!-- %template-output-end:help% -->

--- a/packages/sort-package-json/package.json
+++ b/packages/sort-package-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/sort-package-json",
-  "version": "0.0.1-pre.0",
+  "version": "0.0.1",
   "homepage": "https://github.com/hi-ogawa/js-utils/tree/main/packages/sort-package-json",
   "repository": {
     "type": "git",

--- a/packages/sort-package-json/package.json
+++ b/packages/sort-package-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/sort-package-json",
-  "version": "0.0.0",
+  "version": "0.0.1-pre.0",
   "homepage": "https://github.com/hi-ogawa/js-utils/tree/main/packages/sort-package-json",
   "repository": {
     "type": "git",

--- a/packages/sort-package-json/src/cli.ts
+++ b/packages/sort-package-json/src/cli.ts
@@ -7,16 +7,24 @@ const RULE_MAP = Object.fromEntries(
   Object.entries(RULE).map(([k, v]) => [v, Number(k)])
 );
 
-const HELP = `
+const HELP = `\
 ${name}@${version}
 
 Usage:
-  $ sort-package-json [package.json files...]
-`.trim();
+  sort-package-json [package.json files...]
+
+Example:
+  # sort package.json files in pnpm workspace
+  sort-package-json $(pnpm ls --filter '*' --depth -1 --json | jq -r '.[] | .path' | xargs -i echo {}/package.json)
+`;
 
 function main() {
   const infiles = process.argv.slice(2);
-  if (infiles.includes("-h") || infiles.includes("--help")) {
+  if (
+    infiles.includes("-h") ||
+    infiles.includes("--help") ||
+    infiles.length === 0
+  ) {
     console.log(HELP);
     return;
   }

--- a/packages/sort-package-json/src/cli.ts
+++ b/packages/sort-package-json/src/cli.ts
@@ -13,9 +13,9 @@ ${name}@${version}
 Usage:
   sort-package-json [package.json files...]
 
-Example:
-  # sort package.json files in pnpm workspace
-  sort-package-json $(pnpm ls --filter '*' --depth -1 --json | jq -r '.[] | .path' | xargs -i echo {}/package.json)
+Examples:
+  # Sort package.json files in pnpm workspace
+  sort-package-json $(pnpm ls --filter '*' --depth -1 --json | jq -r '.[] | .path' | xargs -I '{}' echo '{}/package.json')
 `;
 
 function main() {

--- a/packages/sort-package-json/src/scrape-output.json
+++ b/packages/sort-package-json/src/scrape-output.json
@@ -53,6 +53,7 @@
   "pre-commit",
   "commitlint",
   "lint-staged",
+  "nano-staged",
   "config",
   "nodemonConfig",
   "browserify",

--- a/packages/sort-package-json/src/scrape.ts
+++ b/packages/sort-package-json/src/scrape.ts
@@ -2,7 +2,7 @@ import { tinyassert } from "@hiogawa/utils";
 
 async function main() {
   const res = await fetch(
-    "https://github.com/keithamus/sort-package-json/raw/main/defaultRules.md"
+    "https://github.com/keithamus/sort-package-json/raw/v2.6.0/defaultRules.md"
   );
   tinyassert(res.ok);
   const text = await res.text();


### PR DESCRIPTION
Added convenient one-liner in the help:

```
$ sort-package-json --help
@hiogawa/sort-package-json@0.0.1

Usage:
  sort-package-json [package.json files...]

Examples:
  # Sort package.json files in pnpm workspace
  sort-package-json $(pnpm ls --filter '*' --depth -1 --json | jq -r '.[] | .path' | xargs -I '{}' echo '{}/package.json')
```