### PR TITLE
feat: create `tiny-refresh` package

### DIFF
--- a/packages/tiny-refresh/README.md
+++ b/packages/tiny-refresh/README.md
@@ -23,7 +23,6 @@ export default defineConfig({
   plugins: [
     vitePluginTinyRefresh({
       runtime: "react", // "preact/compat", "@hiogawa/tiny-react"
-      debug: true,
     }),
   ],
 });

--- a/packages/tiny-refresh/README.md
+++ b/packages/tiny-refresh/README.md
@@ -1,14 +1,17 @@
 # tiny-refresh
 
-Inspired by simple HMR approach for [`tiny-react`](https://github.com/hi-ogawa/js-utils/pull/144).
+Simple HMR for react-like library.
+This is made as an easy HMR implementation for [`@hiogawa/tiny-react`](https://github.com/hi-ogawa/js-utils/pull/144).
 
-Porting the same idea to `react` as a light weight HMR logic,
-which requires only `useState` and `useEffect` thus supporing old react v16.
+This simplified runtime architecture is inspired by [`solid-refresh`](https://github.com/solidjs/solid-refresh).
 
-## limitations
+## features/limitations
 
+- Only `createElement`, `useState` and `useEffect` are used internally, thus it uniformly supports `react`, `preact`, and `tiny-react`.
+- Simple RegExp based code transform.
 - By default, any change will cause components to remount and thus hook states are not preserved.
 - Adding `// @hmr-unsafe` comment above the component definition will preserve hook states, but each hot update must keep same hook count.
+- Each component will be wrapped with extra component `(ComponentName)_refresh`.
 
 ## usages
 

--- a/packages/tiny-refresh/README.md
+++ b/packages/tiny-refresh/README.md
@@ -1,0 +1,43 @@
+# tiny-refresh
+
+Inspired by simple HMR approach for [`tiny-react`](https://github.com/hi-ogawa/js-utils/pull/144).
+
+Porting the same idea to `react` as a light weight HMR logic,
+which requires only `useState` and `useEffect` thus supporing old react v16.
+
+## limitations
+
+- It requires explicit comment `// @hmr` before component declaration.
+- Using `// @hmr-unsafe` will preserve hook states, but each hot update must keep same hook count.
+- Changes in other components without `// @hmr` won't cause refresh.
+
+## usages
+
+```tsx
+//
+// vite.config.ts
+//
+import { defineConfig } from "vite";
+import { vitePluginTinyRefresh } from "@hiogawa/tiny-refresh/dist/vite";
+
+export default defineConfig({
+  plugins: [
+    vitePluginTinyRefresh({
+      runtime: "react", // "preact/compat", "@hiogawa/tiny-react"
+    }),
+  ],
+});
+```
+
+```tsx
+//
+// demo.tsx
+//
+import { useState } from "react";
+
+// @hmr-unsafe
+export function Demo(props) {
+  const [state, setState] = useState(0);
+  ...
+}
+```

--- a/packages/tiny-refresh/README.md
+++ b/packages/tiny-refresh/README.md
@@ -7,9 +7,8 @@ which requires only `useState` and `useEffect` thus supporing old react v16.
 
 ## limitations
 
-- It requires explicit comment `// @hmr` before component declaration.
-- Using `// @hmr-unsafe` will preserve hook states, but each hot update must keep same hook count.
-- Changes in other components without `// @hmr` won't cause refresh.
+- By default, any change will cause components to remount and thus hook states are not preserved.
+- Adding `// @hmr-unsafe` comment above the component definition will preserve hook states, but each hot update must keep same hook count.
 
 ## usages
 
@@ -24,20 +23,8 @@ export default defineConfig({
   plugins: [
     vitePluginTinyRefresh({
       runtime: "react", // "preact/compat", "@hiogawa/tiny-react"
+      debug: true,
     }),
   ],
 });
-```
-
-```tsx
-//
-// demo.tsx
-//
-import { useState } from "react";
-
-// @hmr-unsafe
-export function Demo(props) {
-  const [state, setState] = useState(0);
-  ...
-}
 ```

--- a/packages/tiny-refresh/examples/react/README.md
+++ b/packages/tiny-refresh/examples/react/README.md
@@ -1,0 +1,5 @@
+# tiny-refresh/examples/react
+
+```sh
+pnpm dev
+```

--- a/packages/tiny-refresh/examples/react/README.md
+++ b/packages/tiny-refresh/examples/react/README.md
@@ -1,5 +1,7 @@
 # tiny-refresh/examples/react
 
 ```sh
+pnpm i
 pnpm dev
+pnpm test-e2e
 ```

--- a/packages/tiny-refresh/examples/react/e2e/hmr.test.ts
+++ b/packages/tiny-refresh/examples/react/e2e/hmr.test.ts
@@ -28,7 +28,10 @@ test("hmr", async ({ page }) => {
   await withEditFile(
     "src/app.tsx",
     (code) => code.replace("<h1>Outer</h1>", "<h2>Outer</h2>"),
-    () => checkInner(0, 100)
+    async () => {
+      await page.locator("h2").getByText("Outer").click();
+      await checkInner(0, 100);
+    }
   );
   await checkInner(0, 100);
 

--- a/packages/tiny-refresh/examples/react/e2e/hmr.test.ts
+++ b/packages/tiny-refresh/examples/react/e2e/hmr.test.ts
@@ -1,0 +1,21 @@
+import fs from "node:fs";
+import { test } from "@playwright/test";
+
+test("hmr", async ({ page }) => {
+  await page.goto("/");
+  await page.locator("#inner1").getByText("props.value + 100 = 100").click();
+  await page.locator("#inner2").getByText("props.value + 100 = 100").click();
+
+  await page.getByRole("button", { name: "+1" }).click();
+  await page.locator("#inner1").getByText("props.value + 100 = 101").click();
+  await page.locator("#inner2").getByText("props.value + 100 = 101").click();
+
+  await editFile("src/app.tsx", (code) => code);
+  await page.locator("#inner1").getByText("props.value + 100 = 101").click();
+  await page.locator("#inner2").getByText("props.value + 100 = 101").click();
+});
+
+async function editFile(filepath: string, edit: (content: string) => string) {
+  const content = await fs.promises.readFile(filepath, "utf-8");
+  await fs.promises.writeFile(filepath, edit(content));
+}

--- a/packages/tiny-refresh/examples/react/e2e/hmr.test.ts
+++ b/packages/tiny-refresh/examples/react/e2e/hmr.test.ts
@@ -5,7 +5,7 @@ test("hmr", async ({ page }) => {
   await page.goto("/");
 
   async function checkInner(value: number, add: number) {
-    const text = `Inner: props.value + ${add} = ${value + add}`;
+    const text = `Inner: counter + ${add} = ${value + add}`;
     await page.locator("#inner1").getByText(text).click();
     await page.locator("#inner2").getByText(text).click();
   }

--- a/packages/tiny-refresh/examples/react/e2e/hmr.test.ts
+++ b/packages/tiny-refresh/examples/react/e2e/hmr.test.ts
@@ -3,19 +3,96 @@ import { test } from "@playwright/test";
 
 test("hmr", async ({ page }) => {
   await page.goto("/");
-  await page.locator("#inner1").getByText("props.value + 100 = 100").click();
-  await page.locator("#inner2").getByText("props.value + 100 = 100").click();
 
+  async function checkInner(value: number, add: number) {
+    const text = `Inner: props.value + ${add} = ${value + add}`;
+    await page.locator("#inner1").getByText(text).click();
+    await page.locator("#inner2").getByText(text).click();
+  }
+
+  await checkInner(0, 100);
+
+  // increment
   await page.getByRole("button", { name: "+1" }).click();
-  await page.locator("#inner1").getByText("props.value + 100 = 101").click();
-  await page.locator("#inner2").getByText("props.value + 100 = 101").click();
+  await checkInner(1, 100);
 
-  await editFile("src/app.tsx", (code) => code);
-  await page.locator("#inner1").getByText("props.value + 100 = 101").click();
-  await page.locator("#inner2").getByText("props.value + 100 = 101").click();
+  // updating 'Inner' keeps 'Outer' state
+  await withEditFile(
+    "src/app.tsx",
+    (code) => code.replace("const add = 100;", "const add = 1000;"),
+    () => checkInner(1, 1000)
+  );
+  await checkInner(1, 100);
+
+  // updating 'Outer' resets state
+  await withEditFile(
+    "src/app.tsx",
+    (code) => code.replace("<h1>Outer</h1>", "<h2>Outer</h2>"),
+    () => checkInner(0, 100)
+  );
+  await checkInner(0, 100);
+
+  // increment
+  await page.getByRole("button", { name: "+1" }).click();
+  await checkInner(1, 100);
+
+  // add @hmr-unsafe
+  await withEditFile(
+    "src/app.tsx",
+    (code) =>
+      code.replace(
+        "export function Outer()",
+        "// @hmr-unsafe\nexport function Outer()"
+      ),
+    async () => {
+      // reset
+      await checkInner(0, 100);
+
+      // increment
+      await page.getByRole("button", { name: "+1" }).click();
+      await checkInner(1, 100);
+
+      // update 'Outer' (make increment double)
+      await withEditFile(
+        "src/app.tsx",
+        (code) => code.replace("(prev) => prev + 1", "(prev) => prev + 2"),
+        async () => {
+          // state is preserved
+          await checkInner(1, 100);
+
+          // increment
+          await page.getByRole("button", { name: "+1" }).click();
+          await checkInner(3, 100);
+
+          // update 'Inner'
+          await withEditFile(
+            "src/app.tsx",
+            (code) => code.replace("const add = 100;", "const add = 1000;"),
+            () => checkInner(3, 1000)
+          );
+        }
+      );
+    }
+  );
 });
+
+async function withEditFile(
+  filepath: string,
+  edit: (content: string) => string,
+  callback: () => void | Promise<void>
+) {
+  const revert = await editFile(filepath, edit);
+  try {
+    await callback();
+  } finally {
+    await revert();
+  }
+}
 
 async function editFile(filepath: string, edit: (content: string) => string) {
   const content = await fs.promises.readFile(filepath, "utf-8");
   await fs.promises.writeFile(filepath, edit(content));
+  return async () => {
+    await fs.promises.writeFile(filepath, content);
+  };
 }

--- a/packages/tiny-refresh/examples/react/e2e/hmr.test.ts
+++ b/packages/tiny-refresh/examples/react/e2e/hmr.test.ts
@@ -4,6 +4,10 @@ import { test } from "@playwright/test";
 test("hmr", async ({ page }) => {
   await page.goto("/");
 
+  async function increment() {
+    await page.getByRole("button", { name: "+1" }).first().click();
+  }
+
   async function checkInner(value: number, add: number) {
     const text = `Inner: counter + ${add} = ${value + add}`;
     await page.locator("#inner1").getByText(text).click();
@@ -13,7 +17,7 @@ test("hmr", async ({ page }) => {
   await checkInner(0, 100);
 
   // increment
-  await page.getByRole("button", { name: "+1" }).click();
+  await increment();
   await checkInner(1, 100);
 
   // updating 'Inner' keeps 'Outer' state
@@ -27,16 +31,16 @@ test("hmr", async ({ page }) => {
   // updating 'Outer' resets state
   await withEditFile(
     "src/app.tsx",
-    (code) => code.replace("<h1>Outer</h1>", "<h2>Outer</h2>"),
+    (code) => code.replace("<h1>outer</h1>", "<h2>outer</h2>"),
     async () => {
-      await page.locator("h2").getByText("Outer").click();
+      await page.locator("h2").getByText("outer").click();
       await checkInner(0, 100);
     }
   );
   await checkInner(0, 100);
 
   // increment
-  await page.getByRole("button", { name: "+1" }).click();
+  await increment();
   await checkInner(1, 100);
 
   // add @hmr-unsafe
@@ -52,7 +56,7 @@ test("hmr", async ({ page }) => {
       await checkInner(0, 100);
 
       // increment
-      await page.getByRole("button", { name: "+1" }).click();
+      await increment();
       await checkInner(1, 100);
 
       // update 'Outer' (make increment double)
@@ -64,7 +68,7 @@ test("hmr", async ({ page }) => {
           await checkInner(1, 100);
 
           // increment
-          await page.getByRole("button", { name: "+1" }).click();
+          await increment();
           await checkInner(3, 100);
 
           // update 'Inner'

--- a/packages/tiny-refresh/examples/react/index.html
+++ b/packages/tiny-refresh/examples/react/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>tiny-refresh demo</title>
+    <meta
+      name="viewport"
+      content="width=device-width, height=device-height, initial-scale=1.0"
+    />
+    <link
+      rel="icon"
+      type="image/svg+xml"
+      href="https://iconify-dark-hiro18181.vercel.app/icon/ri/code-s-line"
+    />
+    <style>
+      html,
+      body,
+      #root {
+        height: 100%;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./src/index.tsx"></script>
+  </body>
+</html>

--- a/packages/tiny-refresh/examples/react/package.json
+++ b/packages/tiny-refresh/examples/react/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "tiny-refresh-examples-react",
+  "private": true,
+  "scripts": {
+    "dev": "vite dev"
+  },
+  "devDependencies": {
+    "@hiogawa/tiny-refresh": "workspace:*",
+    "@hiogawa/theme-script": "workspace:*",
+    "@hiogawa/unocss-preset-antd": "2.2.1-pre.3",
+    "@hiogawa/utils": "workspace:*",
+    "@iconify-json/ri": "^1.1.10",
+    "@types/react": "^18.2.14",
+    "@types/react-dom": "^18.2.7",
+    "@vitejs/plugin-react": "^4.0.1",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "unocss": "^0.53.6",
+    "vite": "^4.4.6"
+  },
+  "volta": {
+    "extends": "../../package.json"
+  }
+}

--- a/packages/tiny-refresh/examples/react/package.json
+++ b/packages/tiny-refresh/examples/react/package.json
@@ -3,14 +3,17 @@
   "private": true,
   "scripts": {
     "dev": "vite dev",
-    "build": "vite build"
+    "build": "vite build",
+    "test-e2e": "playwright test"
   },
   "devDependencies": {
-    "@hiogawa/tiny-refresh": "workspace:*",
     "@hiogawa/theme-script": "workspace:*",
+    "@hiogawa/tiny-refresh": "workspace:*",
     "@hiogawa/unocss-preset-antd": "2.2.1-pre.3",
     "@hiogawa/utils": "workspace:*",
     "@iconify-json/ri": "^1.1.10",
+    "@playwright/test": "^1.38.1",
+    "@types/node": "^20.8.4",
     "@types/react": "^18.2.14",
     "@types/react-dom": "^18.2.7",
     "@vitejs/plugin-react": "^4.0.1",

--- a/packages/tiny-refresh/examples/react/package.json
+++ b/packages/tiny-refresh/examples/react/package.json
@@ -2,7 +2,8 @@
   "name": "tiny-refresh-examples-react",
   "private": true,
   "scripts": {
-    "dev": "vite dev"
+    "dev": "vite dev",
+    "build": "vite build"
   },
   "devDependencies": {
     "@hiogawa/tiny-refresh": "workspace:*",

--- a/packages/tiny-refresh/examples/react/playwright.config.ts
+++ b/packages/tiny-refresh/examples/react/playwright.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig } from "@playwright/test";
+
+const port = 15173;
+
+export default defineConfig({
+  testDir: "./e2e",
+  use: {
+    baseURL: `http://localhost:${port}`,
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: {
+        browserName: "chromium",
+        // https://github.com/microsoft/playwright/issues/1086#issuecomment-592227413
+        viewport: null, // adapt to browser window size specified below
+        launchOptions: {
+          args: ["--window-size=600,800"],
+        },
+      },
+    },
+  ],
+  webServer: {
+    command: `pnpm dev --port ${port}`,
+    port,
+    reuseExistingServer: true,
+  },
+});

--- a/packages/tiny-refresh/examples/react/src/app.tsx
+++ b/packages/tiny-refresh/examples/react/src/app.tsx
@@ -29,13 +29,14 @@ export function State() {
           +1
         </button>
       </div>
-      <StateIner value={state} />
+      <StateInner value={state} />
+      <StateInner value={state} />
     </div>
   );
 }
 
-export function StateIner(props: { value: number }) {
-  const add = 0;
+export function StateInner(props: { value: number }) {
+  const add = 100;
   return (
     <pre>
       props.value + {add} = {props.value + add}

--- a/packages/tiny-refresh/examples/react/src/app.tsx
+++ b/packages/tiny-refresh/examples/react/src/app.tsx
@@ -15,6 +15,7 @@ export function Outer() {
   const [state, setState] = useState(0);
   return (
     <div className="flex flex-col gap-2 border p-4">
+      <h1>Outer</h1>
       <div className="flex gap-2">
         <button
           className="antd-btn antd-btn-default px-1"
@@ -43,7 +44,7 @@ export function Inner(props: { value: number }) {
   const add = 100;
   return (
     <pre>
-      props.value + {add} = {props.value + add}
+      Inner: props.value + {add} = {props.value + add}
     </pre>
   );
 }

--- a/packages/tiny-refresh/examples/react/src/app.tsx
+++ b/packages/tiny-refresh/examples/react/src/app.tsx
@@ -4,17 +4,17 @@ export function Root() {
   return (
     <div>
       <header className="mb-2 p-2 px-4 shadow-md">tiny-refresh demo</header>
-      <div className="flex flex-col w-full max-w-xl mx-auto mt-4 border p-4">
-        <State />
+      <div className="flex flex-col w-full max-w-xl mx-auto p-4">
+        <Outer />
       </div>
     </div>
   );
 }
 
-export function State() {
+export function Outer() {
   const [state, setState] = useState(0);
   return (
-    <div className="flex flex-col gap-1">
+    <div className="flex flex-col gap-2 border p-4">
       <div className="flex gap-2">
         <button
           className="antd-btn antd-btn-default px-1"
@@ -29,13 +29,17 @@ export function State() {
           +1
         </button>
       </div>
-      <StateInner value={state} />
-      <StateInner value={state} />
+      <div id="inner1">
+        <Inner value={state} />
+      </div>
+      <div id="inner2">
+        <Inner value={state} />
+      </div>
     </div>
   );
 }
 
-export function StateInner(props: { value: number }) {
+export function Inner(props: { value: number }) {
   const add = 100;
   return (
     <pre>

--- a/packages/tiny-refresh/examples/react/src/app.tsx
+++ b/packages/tiny-refresh/examples/react/src/app.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { InnerOther } from "./other-file";
 
 export function Root() {
   return (
@@ -36,6 +37,9 @@ export function Outer() {
       <div id="inner2">
         <Inner value={state} />
       </div>
+      <div id="inner3">
+        <InnerOther value={state} />
+      </div>
     </div>
   );
 }
@@ -44,7 +48,7 @@ export function Inner(props: { value: number }) {
   const add = 100;
   return (
     <pre>
-      Inner: props.value + {add} = {props.value + add}
+      Inner: counter + {add} = {props.value + add}
     </pre>
   );
 }

--- a/packages/tiny-refresh/examples/react/src/app.tsx
+++ b/packages/tiny-refresh/examples/react/src/app.tsx
@@ -1,0 +1,44 @@
+import { useState } from "react";
+
+export function Root() {
+  return (
+    <div>
+      <header className="mb-2 p-2 px-4 shadow-md">tiny-refresh demo</header>
+      <div className="flex flex-col w-full max-w-xl mx-auto mt-4 border p-4">
+        <State />
+      </div>
+    </div>
+  );
+}
+
+export function State() {
+  const [state, setState] = useState(0);
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="flex gap-2">
+        <button
+          className="antd-btn antd-btn-default px-1"
+          onClick={() => setState((prev) => prev - 1)}
+        >
+          -1
+        </button>
+        <button
+          className="antd-btn antd-btn-default px-1"
+          onClick={() => setState((prev) => prev + 1)}
+        >
+          +1
+        </button>
+      </div>
+      <StateIner value={state} />
+    </div>
+  );
+}
+
+export function StateIner(props: { value: number }) {
+  const add = 0;
+  return (
+    <pre>
+      props.value + {add} = {props.value + add}
+    </pre>
+  );
+}

--- a/packages/tiny-refresh/examples/react/src/app.tsx
+++ b/packages/tiny-refresh/examples/react/src/app.tsx
@@ -16,8 +16,8 @@ export function Outer() {
   const [state, setState] = useState(0);
   return (
     <div className="flex flex-col gap-2 border p-4">
-      <h1>Outer</h1>
-      <div className="flex gap-2">
+      <div className="flex items-center gap-2">
+        outer = {state}
         <button
           className="antd-btn antd-btn-default px-1"
           onClick={() => setState((prev) => prev - 1)}
@@ -31,12 +31,15 @@ export function Outer() {
           +1
         </button>
       </div>
+      <div className="border-t"></div>
       <div id="inner1">
         <Inner value={state} />
       </div>
+      <div className="border-t"></div>
       <div id="inner2">
         <Inner value={state} />
       </div>
+      <div className="border-t"></div>
       <div id="inner3">
         <InnerOther value={state} />
       </div>
@@ -45,7 +48,7 @@ export function Outer() {
 }
 
 export function Inner(props: { value: number }) {
-  const add = 100;
+  const add = 1010;
   return (
     <pre>
       Inner: counter + {add} = {props.value + add}

--- a/packages/tiny-refresh/examples/react/src/app.tsx
+++ b/packages/tiny-refresh/examples/react/src/app.tsx
@@ -17,7 +17,7 @@ export function Outer() {
   return (
     <div className="flex flex-col gap-2 border p-4">
       <div className="flex items-center gap-2">
-        outer = {state}
+        <h1>outer</h1> = {state}
         <button
           className="antd-btn antd-btn-default px-1"
           onClick={() => setState((prev) => prev - 1)}
@@ -48,7 +48,7 @@ export function Outer() {
 }
 
 export function Inner(props: { value: number }) {
-  const add = 1010;
+  const add = 100;
   return (
     <pre>
       Inner: counter + {add} = {props.value + add}

--- a/packages/tiny-refresh/examples/react/src/index.tsx
+++ b/packages/tiny-refresh/examples/react/src/index.tsx
@@ -1,0 +1,12 @@
+import "virtual:uno.css";
+import { tinyassert } from "@hiogawa/utils";
+import { createRoot } from "react-dom/client";
+import { Root } from "./app";
+
+function main() {
+  const el = document.getElementById("root");
+  tinyassert(el);
+  createRoot(el).render(<Root />);
+}
+
+main();

--- a/packages/tiny-refresh/examples/react/src/other-file.tsx
+++ b/packages/tiny-refresh/examples/react/src/other-file.tsx
@@ -1,8 +1,28 @@
+import { useState } from "react";
+
 export function InnerOther(props: { value: number }) {
   const add = 100;
+  const [inner, setState] = useState(0);
   return (
-    <pre>
-      InnerOther: counter + {add} = {props.value + add}
-    </pre>
+    <div className="flex flex-col gap-1">
+      <div className="flex items-center gap-2">
+        inner2 = {inner}
+        <button
+          className="antd-btn antd-btn-default px-1"
+          onClick={() => setState((prev) => prev - 1)}
+        >
+          -1
+        </button>
+        <button
+          className="antd-btn antd-btn-default px-1"
+          onClick={() => setState((prev) => prev + 1)}
+        >
+          +1
+        </button>
+      </div>
+      <pre>
+        (outer) + (inner2) + {add} = {props.value + inner + add}
+      </pre>
+    </div>
   );
 }

--- a/packages/tiny-refresh/examples/react/src/other-file.tsx
+++ b/packages/tiny-refresh/examples/react/src/other-file.tsx
@@ -1,0 +1,8 @@
+export function InnerOther(props: { value: number }) {
+  const add = 100;
+  return (
+    <pre>
+      InnerOther: counter + {add} = {props.value + add}
+    </pre>
+  );
+}

--- a/packages/tiny-refresh/examples/react/tsconfig.json
+++ b/packages/tiny-refresh/examples/react/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "jsx": "react-jsx"
+  }
+}

--- a/packages/tiny-refresh/examples/react/tsconfig.json
+++ b/packages/tiny-refresh/examples/react/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../../../tsconfig.base.json",
   "include": ["src"],
   "compilerOptions": {
+    "types": ["vite/client"],
     "jsx": "react-jsx"
   }
 }

--- a/packages/tiny-refresh/examples/react/uno.config.ts
+++ b/packages/tiny-refresh/examples/react/uno.config.ts
@@ -1,0 +1,13 @@
+import { antdPreset } from "@hiogawa/unocss-preset-antd";
+import {
+  defineConfig,
+  presetIcons,
+  presetUno,
+  transformerDirectives,
+  transformerVariantGroup,
+} from "unocss";
+
+export default defineConfig({
+  presets: [antdPreset(), presetUno(), presetIcons()],
+  transformers: [transformerDirectives(), transformerVariantGroup()],
+});

--- a/packages/tiny-refresh/examples/react/vite.config.ts
+++ b/packages/tiny-refresh/examples/react/vite.config.ts
@@ -1,0 +1,8 @@
+import { vitePluginTinyRefresh } from "@hiogawa/tiny-refresh/dist/vite";
+import unocss from "unocss/vite";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [unocss() as any, vitePluginTinyRefresh()],
+  clearScreen: false,
+});

--- a/packages/tiny-refresh/examples/react/vite.config.ts
+++ b/packages/tiny-refresh/examples/react/vite.config.ts
@@ -3,11 +3,6 @@ import unocss from "unocss/vite";
 import { defineConfig } from "vite";
 
 export default defineConfig({
-  plugins: [
-    unocss() as any,
-    vitePluginTinyRefresh({
-      debug: true,
-    }),
-  ],
+  plugins: [unocss() as any, vitePluginTinyRefresh()],
   clearScreen: false,
 });

--- a/packages/tiny-refresh/examples/react/vite.config.ts
+++ b/packages/tiny-refresh/examples/react/vite.config.ts
@@ -3,6 +3,11 @@ import unocss from "unocss/vite";
 import { defineConfig } from "vite";
 
 export default defineConfig({
-  plugins: [unocss() as any, vitePluginTinyRefresh()],
+  plugins: [
+    unocss() as any,
+    vitePluginTinyRefresh({
+      debug: true,
+    }),
+  ],
   clearScreen: false,
 });

--- a/packages/tiny-refresh/package.json
+++ b/packages/tiny-refresh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/tiny-refresh",
-  "version": "0.0.1-pre.6",
+  "version": "0.0.1-pre.7",
   "homepage": "https://github.com/hi-ogawa/js-utils/tree/main/packages/tiny-refresh",
   "repository": {
     "type": "git",

--- a/packages/tiny-refresh/package.json
+++ b/packages/tiny-refresh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/tiny-refresh",
-  "version": "0.0.1-pre.4",
+  "version": "0.0.1-pre.5",
   "homepage": "https://github.com/hi-ogawa/js-utils/tree/main/packages/tiny-refresh",
   "repository": {
     "type": "git",

--- a/packages/tiny-refresh/package.json
+++ b/packages/tiny-refresh/package.json
@@ -1,0 +1,62 @@
+{
+  "name": "@hiogawa/tiny-refresh",
+  "version": "0.0.0",
+  "homepage": "https://github.com/hi-ogawa/js-utils/tree/main/packages/tiny-refresh",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/hi-ogawa/js-utils",
+    "directory": "packages/tiny-refresh"
+  },
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs",
+      "types": "./dist/index.d.ts"
+    },
+    "./dist/vite": {
+      "import": "./dist/vite.js",
+      "require": "./dist/vite.cjs",
+      "types": "./dist/vite.d.ts"
+    },
+    "./dist/webpack": {
+      "import": "./dist/webpack.js",
+      "require": "./dist/webpack.cjs",
+      "types": "./dist/webpack.d.ts"
+    }
+  },
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "test": "vitest",
+    "release": "pnpm publish --no-git-checks --access public"
+  },
+  "devDependencies": {
+    "@hiogawa/utils": "workspace:*",
+    "@testing-library/react": "^14.0.0",
+    "@types/react": "^18.2.14",
+    "react": "^18.2.0",
+    "vite": "^4.4.9"
+  },
+  "peerDependencies": {
+    "react": "*",
+    "vite": "*"
+  },
+  "peerDependenciesMeta": {
+    "react": {
+      "optional": true
+    },
+    "vite": {
+      "optional": true
+    }
+  },
+  "volta": {
+    "extends": "../../package.json"
+  }
+}

--- a/packages/tiny-refresh/package.json
+++ b/packages/tiny-refresh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/tiny-refresh",
-  "version": "0.0.1-pre.5",
+  "version": "0.0.1-pre.6",
   "homepage": "https://github.com/hi-ogawa/js-utils/tree/main/packages/tiny-refresh",
   "repository": {
     "type": "git",

--- a/packages/tiny-refresh/package.json
+++ b/packages/tiny-refresh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/tiny-refresh",
-  "version": "0.0.1-pre.0",
+  "version": "0.0.1-pre.1",
   "homepage": "https://github.com/hi-ogawa/js-utils/tree/main/packages/tiny-refresh",
   "repository": {
     "type": "git",

--- a/packages/tiny-refresh/package.json
+++ b/packages/tiny-refresh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/tiny-refresh",
-  "version": "0.0.1-pre.3",
+  "version": "0.0.1-pre.4",
   "homepage": "https://github.com/hi-ogawa/js-utils/tree/main/packages/tiny-refresh",
   "repository": {
     "type": "git",

--- a/packages/tiny-refresh/package.json
+++ b/packages/tiny-refresh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/tiny-refresh",
-  "version": "0.0.1-pre.7",
+  "version": "0.0.1-pre.8",
   "homepage": "https://github.com/hi-ogawa/js-utils/tree/main/packages/tiny-refresh",
   "repository": {
     "type": "git",

--- a/packages/tiny-refresh/package.json
+++ b/packages/tiny-refresh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/tiny-refresh",
-  "version": "0.0.1-pre.1",
+  "version": "0.0.1-pre.2",
   "homepage": "https://github.com/hi-ogawa/js-utils/tree/main/packages/tiny-refresh",
   "repository": {
     "type": "git",

--- a/packages/tiny-refresh/package.json
+++ b/packages/tiny-refresh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/tiny-refresh",
-  "version": "0.0.1-pre.2",
+  "version": "0.0.1-pre.3",
   "homepage": "https://github.com/hi-ogawa/js-utils/tree/main/packages/tiny-refresh",
   "repository": {
     "type": "git",

--- a/packages/tiny-refresh/package.json
+++ b/packages/tiny-refresh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/tiny-refresh",
-  "version": "0.0.0",
+  "version": "0.0.1-pre.0",
   "homepage": "https://github.com/hi-ogawa/js-utils/tree/main/packages/tiny-refresh",
   "repository": {
     "type": "git",

--- a/packages/tiny-refresh/src/index.ts
+++ b/packages/tiny-refresh/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./runtime";
+export * from "./transform";

--- a/packages/tiny-refresh/src/runtime.test.tsx
+++ b/packages/tiny-refresh/src/runtime.test.tsx
@@ -160,4 +160,146 @@ describe(setupHmrVite, () => {
       ]
     `);
   });
+
+  it("unsafe", async () => {
+    const acceptCallbacks: ((newModule?: unknown) => void)[] = [];
+
+    const hot: ViteHot = {
+      accept: (callback) => {
+        acceptCallbacks.push(callback);
+      },
+      invalidate: () => {},
+      data: {},
+    };
+
+    let ChildExport: any;
+
+    function Parent() {
+      return <ChildExport />;
+    }
+
+    const mockFn = vi.fn();
+
+    //
+    // 1st version
+    //
+    {
+      const registry = createHmrRegistry(React);
+
+      ChildExport = createHmrComponent(
+        registry,
+        "Child",
+        function Child() {
+          React.useEffect(() => {
+            mockFn("effect-setup-1");
+            return () => {
+              mockFn("effect-cleanup-1");
+            };
+          }, []);
+          return <div>1</div>;
+        },
+        { remount: false }
+      );
+
+      setupHmrVite(hot, registry);
+    }
+
+    let result = await act(() => render(<Parent />));
+    expect(result.baseElement).toMatchInlineSnapshot(`
+      <body>
+        <div>
+          <div>
+            1
+          </div>
+        </div>
+      </body>
+    `);
+    expect(mockFn.mock.calls).toMatchInlineSnapshot(`
+      [
+        [
+          "effect-setup-1",
+        ],
+      ]
+    `);
+
+    //
+    // 2nd version ("remount: false" will preserve hook state thus no effect run)
+    //
+    {
+      const registry = createHmrRegistry(React);
+
+      // hot update's export doesn't affect original version of export
+      createHmrComponent(
+        registry,
+        "Child",
+        function Child() {
+          React.useEffect(() => {
+            mockFn("effect-setup-2");
+            return () => {
+              mockFn("effect-cleanup-2");
+            };
+          }, []);
+          return <div>2</div>;
+        },
+        { remount: false }
+      );
+
+      setupHmrVite(hot, registry);
+    }
+
+    act(() => acceptCallbacks[0]({}));
+    expect(result.baseElement).toMatchInlineSnapshot(`
+      <body>
+        <div>
+          <div>
+            2
+          </div>
+        </div>
+      </body>
+    `);
+    expect(mockFn.mock.calls).toMatchInlineSnapshot(`
+      [
+        [
+          "effect-setup-1",
+        ],
+      ]
+    `);
+
+    //
+    // 3rd version (removing hook would crash)
+    //
+    {
+      const registry = createHmrRegistry(React);
+
+      createHmrComponent(
+        registry,
+        "Child",
+        function Child() {
+          return <div>3</div>;
+        },
+        { remount: false }
+      );
+
+      setupHmrVite(hot, registry);
+    }
+
+    // TODO: cannot reproduce conditional hook error
+    act(() => acceptCallbacks[1]({}));
+    expect(result.baseElement).toMatchInlineSnapshot(`
+      <body>
+        <div>
+          <div>
+            3
+          </div>
+        </div>
+      </body>
+    `);
+    expect(mockFn.mock.calls).toMatchInlineSnapshot(`
+      [
+        [
+          "effect-setup-1",
+        ],
+      ]
+    `);
+  });
 });

--- a/packages/tiny-refresh/src/runtime.test.tsx
+++ b/packages/tiny-refresh/src/runtime.test.tsx
@@ -32,6 +32,7 @@ describe(setupHmrVite, () => {
 
       const Child = createHmrComponent(
         registry,
+        "Child",
         function Child() {
           return <div>1</div>;
         },
@@ -64,6 +65,7 @@ describe(setupHmrVite, () => {
 
       const Child = createHmrComponent(
         registry,
+        "Child",
         function Child() {
           return <div>2</div>;
         },
@@ -95,6 +97,7 @@ describe(setupHmrVite, () => {
 
       const Child = createHmrComponent(
         registry,
+        "Child",
         function Child() {
           return <div>3</div>;
         },

--- a/packages/tiny-refresh/src/runtime.test.tsx
+++ b/packages/tiny-refresh/src/runtime.test.tsx
@@ -1,0 +1,119 @@
+import { act, cleanup, render } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  type ViteHot,
+  createHmrComponent,
+  createHmrRegistry,
+  setupHmrVite,
+} from "./runtime";
+
+afterEach(cleanup);
+
+describe(setupHmrVite, () => {
+  it("basic", () => {
+    let firstOnNewModule!: (newModule: {} | undefined) => void;
+
+    const hot: ViteHot = {
+      accept: (onNewModule) => {
+        firstOnNewModule ??= onNewModule;
+      },
+      invalidate: () => {},
+      data: {},
+    };
+
+    let ChildExport: any;
+
+    //
+    // 1st version
+    //
+    {
+      const registry = createHmrRegistry(React);
+
+      const Child = createHmrComponent(
+        registry,
+        function Child() {
+          return <div>1</div>;
+        },
+        { remount: true }
+      );
+      ChildExport = Child;
+
+      setupHmrVite(hot, registry);
+    }
+
+    function Parent() {
+      return <ChildExport />;
+    }
+    let result = render(<Parent />);
+    expect(result.baseElement).toMatchInlineSnapshot(`
+      <body>
+        <div>
+          <div>
+            1
+          </div>
+        </div>
+      </body>
+    `);
+
+    //
+    // 2nd version
+    //
+    {
+      const registry = createHmrRegistry(React);
+
+      const Child = createHmrComponent(
+        registry,
+        function Child() {
+          return <div>2</div>;
+        },
+        { remount: true }
+      );
+      // this export itself doesn't affect original version of export
+      Child;
+
+      setupHmrVite(hot, registry);
+    }
+
+    // simulate 1st version's hot.accept
+    act(() => firstOnNewModule({}));
+    expect(result.baseElement).toMatchInlineSnapshot(`
+      <body>
+        <div>
+          <div>
+            2
+          </div>
+        </div>
+      </body>
+    `);
+
+    //
+    // 3rd version
+    //
+    {
+      const registry = createHmrRegistry(React);
+
+      const Child = createHmrComponent(
+        registry,
+        function Child() {
+          return <div>3</div>;
+        },
+        { remount: true }
+      );
+      Child;
+
+      setupHmrVite(hot, registry);
+    }
+
+    act(() => firstOnNewModule({}));
+    expect(result.baseElement).toMatchInlineSnapshot(`
+      <body>
+        <div>
+          <div>
+            3
+          </div>
+        </div>
+      </body>
+    `);
+  });
+});

--- a/packages/tiny-refresh/src/runtime.ts
+++ b/packages/tiny-refresh/src/runtime.ts
@@ -1,0 +1,167 @@
+// inline minimal react typing
+namespace ReactTypes {
+  export type FC = (props: any) => any;
+  export type createElement = (...args: any[]) => any;
+  export type useState = <T>(
+    init: T | (() => T)
+  ) => [T, (next: T | ((prev: T) => T)) => void];
+  export type useEffect = (effect: () => void, deps?: unknown[]) => void;
+}
+
+const REGISTRY_KEY = Symbol.for("tiny-refresh.react");
+
+// cf. https://github.com/solidjs/solid-refresh/blob/22d6a92c91013b6e5d71e520a3d1dcb47d491bba/src/runtime/index.ts
+export interface ViteHot {
+  data: HotData;
+  accept: (onNewModule: (newModule?: unknown) => void) => void;
+  invalidate: () => void;
+}
+
+interface WebpackHot {
+  data?: HotData;
+  accept: (cb?: () => void) => void;
+  dispose: (cb: (data: HotData) => void) => void;
+  invalidate: () => void;
+}
+
+interface HotData {
+  [REGISTRY_KEY]?: HmrRegistry;
+}
+
+interface HmrRegistry {
+  runtime: {
+    createElement: ReactTypes.createElement;
+    useState: ReactTypes.useState;
+    useEffect: ReactTypes.useEffect;
+  };
+  components: Map<string, HmrComponentData>;
+}
+
+interface HmrComponentData {
+  component: ReactTypes.FC;
+  listeners: Set<(fc: () => ReactTypes.FC) => void>;
+  options: HmrComponentOptions;
+}
+
+export function createHmrRegistry(
+  runtime: HmrRegistry["runtime"]
+): HmrRegistry {
+  return {
+    runtime,
+    components: new Map(),
+  };
+}
+
+interface HmrComponentOptions {
+  remount: boolean;
+}
+
+export function createHmrComponent(
+  registry: HmrRegistry,
+  Fc: ReactTypes.FC,
+  options: HmrComponentOptions
+) {
+  const hmrData: HmrComponentData = {
+    component: Fc,
+    listeners: new Set(),
+    options,
+  };
+  registry.components.set(Fc.name, hmrData);
+  const { createElement, useEffect, useState } = registry.runtime;
+
+  // TODO: forward ref?
+  const WrapperComponent: ReactTypes.FC = (props) => {
+    const [LatestFc, setFc] = useState(() => Fc);
+
+    useEffect(() => {
+      // expose setter to force update
+      hmrData.listeners.add(setFc);
+      return () => {
+        hmrData.listeners.delete(setFc);
+      };
+    }, []);
+
+    //
+    // approach 1.
+    //
+    //   h(LatestFc, props)
+    //
+    //   This renders component as a child, which makes it always re-mount on hot update since two functions are not identical.
+    //   Hook states are not preserved, but new component can add/remove hook usage since hook states reset anyways.
+    //
+    // approach 2.
+    //
+    //   LatestFc(props)
+    //
+    //   This directly calls into functional component and use it as implementation of `WrapperComponent`.
+    //   This won't cause re-mount but it must ensure hook usage didn't change, otherwise it'll crash client.
+    //   To employ this approach, we need to detect the usage of hook and conditionally `hot.invalidate`
+    //   only when hook usage is changed.
+    //   however we allow this mode via explicit "// @safe-unsafe" comment.
+    //
+
+    return options.remount ? createElement(LatestFc, props) : LatestFc(props);
+  };
+
+  return WrapperComponent;
+}
+
+function patchRegistry(currentReg: HmrRegistry, latestReg: HmrRegistry) {
+  const keys = new Set([
+    ...currentReg.components.keys(),
+    ...latestReg.components.keys(),
+  ]);
+  for (const key of keys) {
+    const current = currentReg.components.get(key);
+    const latest = latestReg.components.get(key);
+    if (!current || !latest) {
+      return false;
+    }
+    if (current === latest) {
+      continue;
+    }
+    if (current.options.remount !== latest.options.remount) {
+      return false;
+    }
+    // TODO: don't need to reset if source code is exactly same? (based current.component.toString())
+    currentReg.components.set(key, latest);
+    latest.listeners = current.listeners;
+    if (latest.listeners) {
+      latest.listeners.forEach((f) => f(() => latest.component));
+    }
+  }
+  return true;
+}
+
+export function setupHmrVite(hot: ViteHot, registry: HmrRegistry) {
+  hot.data[REGISTRY_KEY] = registry;
+
+  // https://vitejs.dev/guide/api-hmr.html#hot-accept-cb
+  hot.accept((newModule) => {
+    // `registry` refereneced here is the one from the last module which is "accept"-ing new modules.
+    // `hot.data[REGISTRY_KEY]` is always updated by new module before new module is "accept"-ed.
+    const latestRegistry = hot.data[REGISTRY_KEY];
+    const patchSuccess =
+      newModule && latestRegistry && patchRegistry(registry, latestRegistry);
+    if (!patchSuccess) {
+      hot.invalidate();
+    }
+  });
+}
+
+export function setupHmrWebpack(hot: WebpackHot, registry: HmrRegistry) {
+  // perspective flips for webpack since `hot.data` is passed by old module.
+  const lastRegistry = hot.data && hot.data[REGISTRY_KEY];
+  if (lastRegistry) {
+    const patchSuccess = lastRegistry && patchRegistry(lastRegistry, registry);
+    if (!patchSuccess) {
+      hot.invalidate();
+    }
+  }
+
+  // https://webpack.js.org/api/hot-module-replacement/#dispose-or-adddisposehandler
+  hot.dispose((data) => {
+    data[REGISTRY_KEY] = registry;
+  });
+  hot.accept();
+}

--- a/packages/tiny-refresh/src/runtime.ts
+++ b/packages/tiny-refresh/src/runtime.ts
@@ -132,7 +132,6 @@ function patchRegistry(currentReg: HmrRegistry, latestReg: HmrRegistry) {
     // Note that this can cause "false-negative", for example,
     // when a constant defined in the same file has changed
     // and such constant is used by the component.
-    // TODO: add option to disable this via magic comment?
     if (current.component.toString() === latest.component.toString()) {
       continue;
     }

--- a/packages/tiny-refresh/src/runtime.ts
+++ b/packages/tiny-refresh/src/runtime.ts
@@ -65,6 +65,11 @@ export function createHmrComponent(
   Fc: ReactTypes.FC,
   options: HmrComponentOptions
 ) {
+  // "exotic" component (e.g. React.forwardRef) will be filtered out since they are "object"
+  if (typeof Fc !== "function") {
+    return;
+  }
+
   const hmrData: HmrComponentData = {
     component: Fc,
     listeners: new Set(),
@@ -73,7 +78,6 @@ export function createHmrComponent(
   registry.components.set(name, hmrData);
   const { createElement, useEffect, useState } = registry.runtime;
 
-  // TODO: forward ref?
   const WrapperComponent: ReactTypes.FC = (props) => {
     const [LatestFc, setFc] = useState(() => Fc);
 

--- a/packages/tiny-refresh/src/runtime.ts
+++ b/packages/tiny-refresh/src/runtime.ts
@@ -66,7 +66,7 @@ export function createHmrComponent(
   options: HmrComponentOptions
 ) {
   // "exotic" component (e.g. React.forwardRef) will be filtered out since they are "object"
-  if (typeof Fc !== "function") {
+  if (typeof Fc !== "function" || Fc.length > 1) {
     return;
   }
 

--- a/packages/tiny-refresh/src/runtime.ts
+++ b/packages/tiny-refresh/src/runtime.ts
@@ -170,9 +170,14 @@ export function setupHmrVite(hot: ViteHot, registry: HmrRegistry) {
     // `registry` refereneced here is the one from the last module which is "accept"-ing new modules.
     // `hot.data[REGISTRY_KEY]` is always updated by new module before new module is "accept"-ed.
     const latestRegistry = hot.data[REGISTRY_KEY];
-    const patchSuccess =
-      newModule && latestRegistry && patchRegistry(registry, latestRegistry);
-    if (!patchSuccess) {
+
+    // for this case, probably better not to full reload?
+    if (!newModule || !latestRegistry) {
+      hot.invalidate();
+      return;
+    }
+
+    if (!patchRegistry(registry, latestRegistry)) {
       // when child module calls `hot.invalidate()`, it will propagate to parent module.
       // if such parent module has also `setupHmrVite`, then it will simply self-accept and full window reload will not be triggered.
       // So, probably it would be more pragmatic and significant simplification to start with force full reload here

--- a/packages/tiny-refresh/src/runtime.ts
+++ b/packages/tiny-refresh/src/runtime.ts
@@ -58,6 +58,7 @@ interface HmrComponentOptions {
 
 export function createHmrComponent(
   registry: HmrRegistry,
+  name: string,
   Fc: ReactTypes.FC,
   options: HmrComponentOptions
 ) {
@@ -66,8 +67,7 @@ export function createHmrComponent(
     listeners: new Set(),
     options,
   };
-  // TODO: use "name" extracted during transform instead of checking `Fc.name`.
-  registry.components.set(Fc.name, hmrData);
+  registry.components.set(name, hmrData);
   const { createElement, useEffect, useState } = registry.runtime;
 
   // TODO: forward ref?
@@ -98,7 +98,7 @@ export function createHmrComponent(
     //   This won't cause re-mount but it must ensure hook usage didn't change, otherwise it'll crash client.
     //   To employ this approach, we need to detect the usage of hook and conditionally `hot.invalidate`
     //   only when hook usage is changed.
-    //   however we allow this mode via explicit "// @safe-unsafe" comment.
+    //   however we allow this mode via explicit "// @hmr-unsafe" comment.
     //
 
     return options.remount ? createElement(LatestFc, props) : LatestFc(props);

--- a/packages/tiny-refresh/src/runtime.ts
+++ b/packages/tiny-refresh/src/runtime.ts
@@ -34,6 +34,7 @@ interface HmrRegistry {
     useState: ReactTypes.useState;
     useEffect: ReactTypes.useEffect;
   };
+  debug?: boolean;
   components: Map<string, HmrComponentData>;
 }
 
@@ -44,10 +45,12 @@ interface HmrComponentData {
 }
 
 export function createHmrRegistry(
-  runtime: HmrRegistry["runtime"]
+  runtime: HmrRegistry["runtime"],
+  debug?: boolean
 ): HmrRegistry {
   return {
     runtime,
+    debug,
     components: new Map(),
   };
 }
@@ -134,11 +137,13 @@ function patchRegistry(currentReg: HmrRegistry, latestReg: HmrRegistry) {
     if (current.component.toString() === latest.component.toString()) {
       continue;
     }
-    // TODO: optional debug log
-    console.log(
-      `[tiny-refresh] '${key}' (remount = ${latest.options.remount})`
-    );
+    if (latestReg.debug) {
+      console.log(
+        `[tiny-refresh] '${key}' (remount = ${latest.options.remount})`
+      );
+    }
     if (latest.listeners) {
+      // TODO: useTransition?
       latest.listeners.forEach((f) => f(() => latest.component));
     }
   }

--- a/packages/tiny-refresh/src/runtime.ts
+++ b/packages/tiny-refresh/src/runtime.ts
@@ -65,11 +65,6 @@ export function createHmrComponent(
   Fc: ReactTypes.FC,
   options: HmrComponentOptions
 ) {
-  // "exotic" component (e.g. React.forwardRef) will be filtered out since they are "object"
-  if (typeof Fc !== "function" || Fc.length > 1) {
-    return;
-  }
-
   const hmrData: HmrComponentData = {
     component: Fc,
     listeners: new Set(),

--- a/packages/tiny-refresh/src/runtime.ts
+++ b/packages/tiny-refresh/src/runtime.ts
@@ -150,9 +150,11 @@ function patchRegistry(currentReg: HmrRegistry, latestReg: HmrRegistry) {
     if (current.component.toString() === latest.component.toString()) {
       continue;
     }
-    console.log(
-      `[tiny-refresh] refresh '${key}' (remount = ${latest.options.remount})`
-    );
+    if (latestReg.debug) {
+      console.log(
+        `[tiny-refresh] refresh '${key}' (remount = ${latest.options.remount}, listeners.size = ${latest.listeners.size})`
+      );
+    }
     for (const setState of latest.listeners) {
       setState(latest);
     }

--- a/packages/tiny-refresh/src/runtime.ts
+++ b/packages/tiny-refresh/src/runtime.ts
@@ -66,7 +66,7 @@ export function createHmrComponent(
     listeners: new Set(),
     options,
   };
-  // TODO: use "name" extracted during transform instead of runtime.
+  // TODO: use "name" extracted during transform instead of checking `Fc.name`.
   registry.components.set(Fc.name, hmrData);
   const { createElement, useEffect, useState } = registry.runtime;
 
@@ -134,10 +134,9 @@ function patchRegistry(currentReg: HmrRegistry, latestReg: HmrRegistry) {
     if (current.component.toString() === latest.component.toString()) {
       continue;
     }
-    // TODO: debug log option
-    // TODO: log with file path
+    // TODO: optional debug log
     console.log(
-      `[tiny-refresh] update '${key}' (remount = ${latest.options.remount})`
+      `[tiny-refresh] '${key}' (remount = ${latest.options.remount})`
     );
     if (latest.listeners) {
       latest.listeners.forEach((f) => f(() => latest.component));

--- a/packages/tiny-refresh/src/runtime.ts
+++ b/packages/tiny-refresh/src/runtime.ts
@@ -34,7 +34,7 @@ interface HmrRegistry {
     useState: ReactTypes.useState;
     useEffect: ReactTypes.useEffect;
   };
-  debug?: boolean;
+  debug?: boolean; // to hide log for testing
   componentMap: Map<string, HmrComponentData>;
 }
 
@@ -150,7 +150,8 @@ function patchRegistry(currentReg: HmrRegistry, latestReg: HmrRegistry) {
       continue;
     }
     if (latestReg.debug) {
-      console.log(
+      // cf. "[vite] hot updated" log https://github.com/vitejs/vite/pull/8855
+      console.debug(
         `[tiny-refresh] refresh '${key}' (remount = ${latest.options.remount}, listeners.size = ${latest.listeners.size})`
       );
     }

--- a/packages/tiny-refresh/src/runtime.ts
+++ b/packages/tiny-refresh/src/runtime.ts
@@ -77,7 +77,6 @@ export function createHmrComponent(
     const [LatestFc, setFc] = useState(() => Fc);
 
     useEffect(() => {
-      console.log("== useEffect", name);
       // expose setter to force update
       hmrData.listeners.add(setFc);
       return () => {
@@ -133,11 +132,9 @@ function patchRegistry(currentReg: HmrRegistry, latestReg: HmrRegistry) {
     if (current.component.toString() === latest.component.toString()) {
       continue;
     }
-    if (latestReg.debug) {
-      console.log(
-        `[tiny-refresh] refresh '${key}' (remount = ${latest.options.remount})`
-      );
-    }
+    console.log(
+      `[tiny-refresh] refresh '${key}' (remount = ${latest.options.remount})`
+    );
     for (const setState of latest.listeners) {
       setState(() => latest.component);
     }
@@ -159,7 +156,7 @@ export function setupHmrVite(hot: ViteHot, registry: HmrRegistry) {
       // when child module calls `hot.invalidate()`, it'll propagate to parent module.
       // if such parent module has also `setupHmrVite`, then it will simply self-accept and full window reload will not be triggered.
       // So, probably it would be more pragmatic and significant simplification to start with force full reload here
-      // instead of doing `hot.invalidate()` while trying to synchronize `registry` and `latestRegistry`.
+      // instead of doing `hot.invalidate()` and trying hard to synchronize `registry` and `latestRegistry` somehow.
       console.log(`[tiny-refresh] full reload`);
       window.location.reload();
     }

--- a/packages/tiny-refresh/src/runtime.ts
+++ b/packages/tiny-refresh/src/runtime.ts
@@ -97,11 +97,10 @@ export function createHmrComponent(
     //
     //   fc(props)
     //
-    //   This directly calls into functional component and use it as implementation of `WrapperComponent`.
+    //   This directly calls into functional component and use it as implementation of `UnsafeWrapperFc`.
     //   This won't cause re-mount but it must ensure hook usage didn't change, otherwise it'll crash client.
-    //   To employ this approach, we need to detect the usage of hook and conditionally `hot.invalidate`
-    //   only when hook usage is changed.
-    //   however we allow this mode via explicit "// @hmr-unsafe" comment.
+    //   Ideally, to employ this approach, we need to detect the usage of hook and force remount when hook usage is changed.
+    //   For now, however, we allow this mode via explicit "// @hmr-unsafe" comment.
     //
 
     return latest.options.remount

--- a/packages/tiny-refresh/src/transform.test.ts
+++ b/packages/tiny-refresh/src/transform.test.ts
@@ -104,6 +104,12 @@ function CompFn2() {
   return <div>hello</div>;
 }
 
+// @hmr-disable
+function CompNooo() {
+  return <div>hello</div>;
+}
+
+
 const lower = 0;
 const UPPER = 1;
 
@@ -140,6 +146,12 @@ const UPPER = 1;
       function CompFn2() {
         return <div>hello</div>;
       }
+
+      // @hmr-disable
+      function CompNooo() {
+        return <div>hello</div>;
+      }
+
 
       const lower = 0;
       let UPPER = 1;
@@ -182,5 +194,27 @@ const UPPER = 1;
       }
       "
     `);
+  });
+
+  it("auto-detect", () => {
+    const input = `\
+// @hmr-disable-all
+
+export default function CompFn() {
+  return <div>hello</div>;
+}
+
+export let CompLet = () => {
+  return <div>hello</div>;
+}
+
+`;
+    expect(
+      hmrTransform(input, {
+        runtime: "react",
+        bundler: "vite",
+        autoDetect: true,
+      })
+    ).toMatchInlineSnapshot("undefined");
   });
 });

--- a/packages/tiny-refresh/src/transform.test.ts
+++ b/packages/tiny-refresh/src/transform.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { hmrTransform } from "./transform";
+
+describe(hmrTransform, () => {
+  it("basic", () => {
+    const input = `\
+// @hmr
+function CompFn() {
+  return <div>hello</div>;
+}
+
+// @hmr
+let CompLet = () => {
+  return <div>hello</div>;
+}
+
+// @hmr
+const CompConst = () => {
+  return <div>hello</div>;
+}
+
+function CompNooo() {
+  return <div>hello</div>;
+}
+`;
+    expect(hmrTransform(input, { runtime: "react", bundler: "vite" }))
+      .toMatchInlineSnapshot(`
+        "
+        import * as $$runtime from \\"react\\",
+        import * as $$refresh from \\"@hiogawa/tiny-refresh\\";
+        const $$registry = $$refresh.createHmrRegistry({
+          createElement: $$runtime.createElement,
+          useState: $$runtime.useState,
+          useEffect: $$runtime.useEffect,
+        });
+
+        // @hmr
+        function CompFn() {
+          return <div>hello</div>;
+        }
+
+        // @hmr
+        let CompLet = () => {
+          return <div>hello</div>;
+        }
+
+        // @hmr
+        let CompConst = () => {
+          return <div>hello</div>;
+        }
+
+        function CompNooo() {
+          return <div>hello</div>;
+        }
+
+
+        var $$tmp_CompFn = CompFn;
+        CompFn = $$refresh.createHmrComponent($$registry, $$tmp_CompFn, { remount: true });
+
+
+        var $$tmp_CompLet = CompLet;
+        CompLet = $$refresh.createHmrComponent($$registry, $$tmp_CompLet, { remount: true });
+
+
+        var $$tmp_CompConst = CompConst;
+        CompConst = $$refresh.createHmrComponent($$registry, $$tmp_CompConst, { remount: true });
+
+
+        if (import.meta.hot) {
+          $$refresh.setupHmrVite(import.meta.hot, $$registry);
+          () => import.meta.hot.accept();
+        }
+        "
+      `);
+  });
+});

--- a/packages/tiny-refresh/src/transform.test.ts
+++ b/packages/tiny-refresh/src/transform.test.ts
@@ -26,7 +26,7 @@ function CompNooo() {
     expect(hmrTransform(input, { runtime: "react", bundler: "vite" }))
       .toMatchInlineSnapshot(`
         "
-        import * as $$runtime from \\"react\\",
+        import * as $$runtime from \\"react\\";
         import * as $$refresh from \\"@hiogawa/tiny-refresh\\";
         const $$registry = $$refresh.createHmrRegistry({
           createElement: $$runtime.createElement,

--- a/packages/tiny-refresh/src/transform.test.ts
+++ b/packages/tiny-refresh/src/transform.test.ts
@@ -5,16 +5,16 @@ describe(hmrTransform, () => {
   it("basic", () => {
     const input = `\
 // @hmr
-function CompFn() {
+export default function CompFn() {
   return <div>hello</div>;
 }
 
 // @hmr
-let CompLet = () => {
+export let CompLet = () => {
   return <div>hello</div>;
 }
 
-// @hmr
+// @hmr-unsafe
 const CompConst = () => {
   return <div>hello</div>;
 }
@@ -23,54 +23,164 @@ function CompNooo() {
   return <div>hello</div>;
 }
 `;
-    expect(hmrTransform(input, { runtime: "react", bundler: "vite" }))
-      .toMatchInlineSnapshot(`
-        "
-        import * as $$runtime from \\"react\\";
-        import * as $$refresh from \\"@hiogawa/tiny-refresh\\";
-        const $$registry = $$refresh.createHmrRegistry({
-          createElement: $$runtime.createElement,
-          useState: $$runtime.useState,
-          useEffect: $$runtime.useEffect,
-        });
+    expect(
+      hmrTransform(input, {
+        runtime: "react",
+        bundler: "vite",
+        autoDetect: false,
+      })
+    ).toMatchInlineSnapshot(`
+      "
+      import * as $$runtime from \\"react\\";
+      import * as $$refresh from \\"@hiogawa/tiny-refresh\\";
+      const $$registry = $$refresh.createHmrRegistry({
+        createElement: $$runtime.createElement,
+        useState: $$runtime.useState,
+        useEffect: $$runtime.useEffect,
+      });
 
-        // @hmr
-        function CompFn() {
-          return <div>hello</div>;
-        }
+      // @hmr
+      export default function CompFn() {
+        return <div>hello</div>;
+      }
 
-        // @hmr
-        let CompLet = () => {
-          return <div>hello</div>;
-        }
+      // @hmr
+      export let CompLet = () => {
+        return <div>hello</div>;
+      }
 
-        // @hmr
-        let CompConst = () => {
-          return <div>hello</div>;
-        }
+      // @hmr-unsafe
+      let CompConst = () => {
+        return <div>hello</div>;
+      }
 
-        function CompNooo() {
-          return <div>hello</div>;
-        }
+      function CompNooo() {
+        return <div>hello</div>;
+      }
 
 
+      if (typeof CompFn === \\"function\\") {
         var $$tmp_CompFn = CompFn;
         CompFn = $$refresh.createHmrComponent($$registry, $$tmp_CompFn, { remount: true });
+      }
 
 
+      if (typeof CompLet === \\"function\\") {
         var $$tmp_CompLet = CompLet;
         CompLet = $$refresh.createHmrComponent($$registry, $$tmp_CompLet, { remount: true });
+      }
 
 
+      if (typeof CompConst === \\"function\\") {
         var $$tmp_CompConst = CompConst;
-        CompConst = $$refresh.createHmrComponent($$registry, $$tmp_CompConst, { remount: true });
+        CompConst = $$refresh.createHmrComponent($$registry, $$tmp_CompConst, { remount: false });
+      }
 
 
-        if (import.meta.hot) {
-          $$refresh.setupHmrVite(import.meta.hot, $$registry);
-          () => import.meta.hot.accept();
-        }
-        "
-      `);
+      if (import.meta.hot) {
+        $$refresh.setupHmrVite(import.meta.hot, $$registry);
+        () => import.meta.hot.accept();
+      }
+      "
+    `);
+  });
+
+  it("auto-detect", () => {
+    const input = `\
+export default function CompFn() {
+  return <div>hello</div>;
+}
+
+export let CompLet = () => {
+  return <div>hello</div>;
+}
+
+// @hmr-unsafe
+const CompConst = () => {
+  return <div>hello</div>;
+}
+
+function CompFn2() {
+  return <div>hello</div>;
+}
+
+const lower = 0;
+const UPPER = 1;
+
+`;
+    expect(
+      hmrTransform(input, {
+        runtime: "react",
+        bundler: "vite",
+        autoDetect: true,
+      })
+    ).toMatchInlineSnapshot(`
+      "
+      import * as $$runtime from \\"react\\";
+      import * as $$refresh from \\"@hiogawa/tiny-refresh\\";
+      const $$registry = $$refresh.createHmrRegistry({
+        createElement: $$runtime.createElement,
+        useState: $$runtime.useState,
+        useEffect: $$runtime.useEffect,
+      });
+
+      export default function CompFn() {
+        return <div>hello</div>;
+      }
+
+      export let CompLet = () => {
+        return <div>hello</div>;
+      }
+
+      // @hmr-unsafe
+      let CompConst = () => {
+        return <div>hello</div>;
+      }
+
+      function CompFn2() {
+        return <div>hello</div>;
+      }
+
+      const lower = 0;
+      let UPPER = 1;
+
+
+
+      if (typeof CompFn === \\"function\\") {
+        var $$tmp_CompFn = CompFn;
+        CompFn = $$refresh.createHmrComponent($$registry, $$tmp_CompFn, { remount: true });
+      }
+
+
+      if (typeof CompLet === \\"function\\") {
+        var $$tmp_CompLet = CompLet;
+        CompLet = $$refresh.createHmrComponent($$registry, $$tmp_CompLet, { remount: true });
+      }
+
+
+      if (typeof CompConst === \\"function\\") {
+        var $$tmp_CompConst = CompConst;
+        CompConst = $$refresh.createHmrComponent($$registry, $$tmp_CompConst, { remount: false });
+      }
+
+
+      if (typeof CompFn2 === \\"function\\") {
+        var $$tmp_CompFn2 = CompFn2;
+        CompFn2 = $$refresh.createHmrComponent($$registry, $$tmp_CompFn2, { remount: true });
+      }
+
+
+      if (typeof UPPER === \\"function\\") {
+        var $$tmp_UPPER = UPPER;
+        UPPER = $$refresh.createHmrComponent($$registry, $$tmp_UPPER, { remount: true });
+      }
+
+
+      if (import.meta.hot) {
+        $$refresh.setupHmrVite(import.meta.hot, $$registry);
+        () => import.meta.hot.accept();
+      }
+      "
+    `);
   });
 });

--- a/packages/tiny-refresh/src/transform.test.ts
+++ b/packages/tiny-refresh/src/transform.test.ts
@@ -59,16 +59,22 @@ function CompNooo() {
       }
 
 
-      var $$tmp_CompFn = CompFn;
-      CompFn = $$refresh.createHmrComponent($$registry, \\"CompFn\\", $$tmp_CompFn, { remount: true });
+      if (typeof CompFn === \\"function\\" && CompFn.length <= 1) {
+        var $$tmp_CompFn = CompFn;
+        CompFn = $$refresh.createHmrComponent($$registry, \\"CompFn\\", $$tmp_CompFn, { remount: true });
+      }
 
 
-      var $$tmp_CompLet = CompLet;
-      CompLet = $$refresh.createHmrComponent($$registry, \\"CompLet\\", $$tmp_CompLet, { remount: true });
+      if (typeof CompLet === \\"function\\" && CompLet.length <= 1) {
+        var $$tmp_CompLet = CompLet;
+        CompLet = $$refresh.createHmrComponent($$registry, \\"CompLet\\", $$tmp_CompLet, { remount: true });
+      }
 
 
-      var $$tmp_CompConst = CompConst;
-      CompConst = $$refresh.createHmrComponent($$registry, \\"CompConst\\", $$tmp_CompConst, { remount: false });
+      if (typeof CompConst === \\"function\\" && CompConst.length <= 1) {
+        var $$tmp_CompConst = CompConst;
+        CompConst = $$refresh.createHmrComponent($$registry, \\"CompConst\\", $$tmp_CompConst, { remount: false });
+      }
 
 
       if (import.meta.hot) {
@@ -140,24 +146,34 @@ const UPPER = 1;
 
 
 
-      var $$tmp_CompFn = CompFn;
-      CompFn = $$refresh.createHmrComponent($$registry, \\"CompFn\\", $$tmp_CompFn, { remount: true });
+      if (typeof CompFn === \\"function\\" && CompFn.length <= 1) {
+        var $$tmp_CompFn = CompFn;
+        CompFn = $$refresh.createHmrComponent($$registry, \\"CompFn\\", $$tmp_CompFn, { remount: true });
+      }
 
 
-      var $$tmp_CompLet = CompLet;
-      CompLet = $$refresh.createHmrComponent($$registry, \\"CompLet\\", $$tmp_CompLet, { remount: true });
+      if (typeof CompLet === \\"function\\" && CompLet.length <= 1) {
+        var $$tmp_CompLet = CompLet;
+        CompLet = $$refresh.createHmrComponent($$registry, \\"CompLet\\", $$tmp_CompLet, { remount: true });
+      }
 
 
-      var $$tmp_CompConst = CompConst;
-      CompConst = $$refresh.createHmrComponent($$registry, \\"CompConst\\", $$tmp_CompConst, { remount: false });
+      if (typeof CompConst === \\"function\\" && CompConst.length <= 1) {
+        var $$tmp_CompConst = CompConst;
+        CompConst = $$refresh.createHmrComponent($$registry, \\"CompConst\\", $$tmp_CompConst, { remount: false });
+      }
 
 
-      var $$tmp_CompFn2 = CompFn2;
-      CompFn2 = $$refresh.createHmrComponent($$registry, \\"CompFn2\\", $$tmp_CompFn2, { remount: true });
+      if (typeof CompFn2 === \\"function\\" && CompFn2.length <= 1) {
+        var $$tmp_CompFn2 = CompFn2;
+        CompFn2 = $$refresh.createHmrComponent($$registry, \\"CompFn2\\", $$tmp_CompFn2, { remount: true });
+      }
 
 
-      var $$tmp_UPPER = UPPER;
-      UPPER = $$refresh.createHmrComponent($$registry, \\"UPPER\\", $$tmp_UPPER, { remount: true });
+      if (typeof UPPER === \\"function\\" && UPPER.length <= 1) {
+        var $$tmp_UPPER = UPPER;
+        UPPER = $$refresh.createHmrComponent($$registry, \\"UPPER\\", $$tmp_UPPER, { remount: true });
+      }
 
 
       if (import.meta.hot) {

--- a/packages/tiny-refresh/src/transform.test.ts
+++ b/packages/tiny-refresh/src/transform.test.ts
@@ -37,7 +37,7 @@ function CompNooo() {
         createElement: $$runtime.createElement,
         useState: $$runtime.useState,
         useEffect: $$runtime.useEffect,
-      });
+      }, false);
 
       // @hmr
       export default function CompFn() {
@@ -122,7 +122,7 @@ const UPPER = 1;
         createElement: $$runtime.createElement,
         useState: $$runtime.useState,
         useEffect: $$runtime.useEffect,
-      });
+      }, false);
 
       export default function CompFn() {
         return <div>hello</div>;

--- a/packages/tiny-refresh/src/transform.test.ts
+++ b/packages/tiny-refresh/src/transform.test.ts
@@ -59,22 +59,16 @@ function CompNooo() {
       }
 
 
-      if (typeof CompFn === \\"function\\") {
-        var $$tmp_CompFn = CompFn;
-        CompFn = $$refresh.createHmrComponent($$registry, \\"CompFn\\", $$tmp_CompFn, { remount: true });
-      }
+      var $$tmp_CompFn = CompFn;
+      CompFn = $$refresh.createHmrComponent($$registry, \\"CompFn\\", $$tmp_CompFn, { remount: true });
 
 
-      if (typeof CompLet === \\"function\\") {
-        var $$tmp_CompLet = CompLet;
-        CompLet = $$refresh.createHmrComponent($$registry, \\"CompLet\\", $$tmp_CompLet, { remount: true });
-      }
+      var $$tmp_CompLet = CompLet;
+      CompLet = $$refresh.createHmrComponent($$registry, \\"CompLet\\", $$tmp_CompLet, { remount: true });
 
 
-      if (typeof CompConst === \\"function\\") {
-        var $$tmp_CompConst = CompConst;
-        CompConst = $$refresh.createHmrComponent($$registry, \\"CompConst\\", $$tmp_CompConst, { remount: false });
-      }
+      var $$tmp_CompConst = CompConst;
+      CompConst = $$refresh.createHmrComponent($$registry, \\"CompConst\\", $$tmp_CompConst, { remount: false });
 
 
       if (import.meta.hot) {
@@ -146,34 +140,24 @@ const UPPER = 1;
 
 
 
-      if (typeof CompFn === \\"function\\") {
-        var $$tmp_CompFn = CompFn;
-        CompFn = $$refresh.createHmrComponent($$registry, \\"CompFn\\", $$tmp_CompFn, { remount: true });
-      }
+      var $$tmp_CompFn = CompFn;
+      CompFn = $$refresh.createHmrComponent($$registry, \\"CompFn\\", $$tmp_CompFn, { remount: true });
 
 
-      if (typeof CompLet === \\"function\\") {
-        var $$tmp_CompLet = CompLet;
-        CompLet = $$refresh.createHmrComponent($$registry, \\"CompLet\\", $$tmp_CompLet, { remount: true });
-      }
+      var $$tmp_CompLet = CompLet;
+      CompLet = $$refresh.createHmrComponent($$registry, \\"CompLet\\", $$tmp_CompLet, { remount: true });
 
 
-      if (typeof CompConst === \\"function\\") {
-        var $$tmp_CompConst = CompConst;
-        CompConst = $$refresh.createHmrComponent($$registry, \\"CompConst\\", $$tmp_CompConst, { remount: false });
-      }
+      var $$tmp_CompConst = CompConst;
+      CompConst = $$refresh.createHmrComponent($$registry, \\"CompConst\\", $$tmp_CompConst, { remount: false });
 
 
-      if (typeof CompFn2 === \\"function\\") {
-        var $$tmp_CompFn2 = CompFn2;
-        CompFn2 = $$refresh.createHmrComponent($$registry, \\"CompFn2\\", $$tmp_CompFn2, { remount: true });
-      }
+      var $$tmp_CompFn2 = CompFn2;
+      CompFn2 = $$refresh.createHmrComponent($$registry, \\"CompFn2\\", $$tmp_CompFn2, { remount: true });
 
 
-      if (typeof UPPER === \\"function\\") {
-        var $$tmp_UPPER = UPPER;
-        UPPER = $$refresh.createHmrComponent($$registry, \\"UPPER\\", $$tmp_UPPER, { remount: true });
-      }
+      var $$tmp_UPPER = UPPER;
+      UPPER = $$refresh.createHmrComponent($$registry, \\"UPPER\\", $$tmp_UPPER, { remount: true });
 
 
       if (import.meta.hot) {

--- a/packages/tiny-refresh/src/transform.test.ts
+++ b/packages/tiny-refresh/src/transform.test.ts
@@ -61,19 +61,19 @@ function CompNooo() {
 
       if (typeof CompFn === \\"function\\") {
         var $$tmp_CompFn = CompFn;
-        CompFn = $$refresh.createHmrComponent($$registry, $$tmp_CompFn, { remount: true });
+        CompFn = $$refresh.createHmrComponent($$registry, \\"CompFn\\", $$tmp_CompFn, { remount: true });
       }
 
 
       if (typeof CompLet === \\"function\\") {
         var $$tmp_CompLet = CompLet;
-        CompLet = $$refresh.createHmrComponent($$registry, $$tmp_CompLet, { remount: true });
+        CompLet = $$refresh.createHmrComponent($$registry, \\"CompLet\\", $$tmp_CompLet, { remount: true });
       }
 
 
       if (typeof CompConst === \\"function\\") {
         var $$tmp_CompConst = CompConst;
-        CompConst = $$refresh.createHmrComponent($$registry, $$tmp_CompConst, { remount: false });
+        CompConst = $$refresh.createHmrComponent($$registry, \\"CompConst\\", $$tmp_CompConst, { remount: false });
       }
 
 
@@ -148,31 +148,31 @@ const UPPER = 1;
 
       if (typeof CompFn === \\"function\\") {
         var $$tmp_CompFn = CompFn;
-        CompFn = $$refresh.createHmrComponent($$registry, $$tmp_CompFn, { remount: true });
+        CompFn = $$refresh.createHmrComponent($$registry, \\"CompFn\\", $$tmp_CompFn, { remount: true });
       }
 
 
       if (typeof CompLet === \\"function\\") {
         var $$tmp_CompLet = CompLet;
-        CompLet = $$refresh.createHmrComponent($$registry, $$tmp_CompLet, { remount: true });
+        CompLet = $$refresh.createHmrComponent($$registry, \\"CompLet\\", $$tmp_CompLet, { remount: true });
       }
 
 
       if (typeof CompConst === \\"function\\") {
         var $$tmp_CompConst = CompConst;
-        CompConst = $$refresh.createHmrComponent($$registry, $$tmp_CompConst, { remount: false });
+        CompConst = $$refresh.createHmrComponent($$registry, \\"CompConst\\", $$tmp_CompConst, { remount: false });
       }
 
 
       if (typeof CompFn2 === \\"function\\") {
         var $$tmp_CompFn2 = CompFn2;
-        CompFn2 = $$refresh.createHmrComponent($$registry, $$tmp_CompFn2, { remount: true });
+        CompFn2 = $$refresh.createHmrComponent($$registry, \\"CompFn2\\", $$tmp_CompFn2, { remount: true });
       }
 
 
       if (typeof UPPER === \\"function\\") {
         var $$tmp_UPPER = UPPER;
-        UPPER = $$refresh.createHmrComponent($$registry, $$tmp_UPPER, { remount: true });
+        UPPER = $$refresh.createHmrComponent($$registry, \\"UPPER\\", $$tmp_UPPER, { remount: true });
       }
 
 

--- a/packages/tiny-refresh/src/transform.ts
+++ b/packages/tiny-refresh/src/transform.ts
@@ -93,9 +93,13 @@ function spliceString(
 
 // re-assigning over function declaration is sketchy but seems to be okay
 // cf. https://eslint.org/docs/latest/rules/no-func-assign
+
+// "exotic" component (e.g. React.forwardRef) will be filtered out since they are "object"
 const wrapCreateHmrComponent = (name: string, remount: boolean) => /* js */ `
-var $$tmp_${name} = ${name};
-${name} = $$refresh.createHmrComponent($$registry, "${name}", $$tmp_${name}, { remount: ${remount} });
+if (typeof ${name} === "function" && ${name}.length <= 1) {
+  var $$tmp_${name} = ${name};
+  ${name} = $$refresh.createHmrComponent($$registry, "${name}", $$tmp_${name}, { remount: ${remount} });
+}
 `;
 
 // /* js */ comment is for https://github.com/mjbvz/vscode-comment-tagged-templates

--- a/packages/tiny-refresh/src/transform.ts
+++ b/packages/tiny-refresh/src/transform.ts
@@ -1,0 +1,109 @@
+import { tinyassert } from "@hiogawa/utils";
+
+// based on packages/tiny-react/src/hmr/transform.ts
+
+const PRAGMA_RE = /^\s*\/\/\s*@hmr/g;
+
+interface HmrTransformOptions {
+  runtime: string; // e.g. "react", "preact/compat", "@hiogawa/tiny-react"
+  refreshRuntime?: string; // allow "@hiogawa/tiny-react" to re-export refresh runtime by itself to simplify dependency
+  bundler: "vite" | "webpack4";
+}
+
+export function hmrTransform(
+  code: string,
+  options: HmrTransformOptions
+): string | undefined {
+  const lines = code.split("\n");
+  const newLines = [...lines];
+  const extraCodes: string[] = [];
+
+  for (let i = 0; i < lines.length - 1; i++) {
+    const line = lines[i];
+    if (line.match(PRAGMA_RE)) {
+      const found = transformComponentDecl(lines[i + 1]);
+      if (found) {
+        newLines[i + 1] = found[0];
+        extraCodes.push(
+          wrapCreateHmrComponent(found[1], !line.includes("@hmr-unsafe"))
+        );
+      }
+    }
+  }
+  if (extraCodes.length === 0) {
+    return;
+  }
+  return [
+    headerCode(
+      options.runtime,
+      options.refreshRuntime ?? "@hiogawa/tiny-refresh"
+    ),
+    ...newLines,
+    ...extraCodes,
+    options.bundler === "vite" ? FOOTER_CODE_VITE : FOOTER_CODE_WEBPACK4,
+  ].join("\n");
+}
+
+const COMPONENT_DECL_RE = /(function|let|const)\s*(\w+)/;
+
+// find identifier from the next line of "@hmr" comment
+//   function SomeComponent
+//   let SomeComponent
+//   const SomeComponent (then `const` will be transformed to `let`)
+function transformComponentDecl(line: string): [string, string] | undefined {
+  const match = line.match(COMPONENT_DECL_RE);
+  if (match) {
+    const [, declType, name] = match;
+    if (declType === "const") {
+      tinyassert(typeof match.index === "number");
+      line = spliceString(line, match.index, "const".length, "let");
+    }
+    return [line, name];
+  }
+  return;
+}
+
+function spliceString(
+  input: string,
+  startIndex: number,
+  deleteLength: number,
+  inserted: string
+) {
+  return (
+    input.slice(0, startIndex) +
+    inserted +
+    input.slice(startIndex + deleteLength)
+  );
+}
+
+// re-assigning over function declaration is sketchy but seems to be okay
+// cf. https://eslint.org/docs/latest/rules/no-func-assign
+const wrapCreateHmrComponent = (name: string, remount: boolean) => /* js */ `
+var $$tmp_${name} = ${name};
+${name} = $$refresh.createHmrComponent($$registry, $$tmp_${name}, { remount: ${remount} });
+`;
+
+// /* js */ comment is for https://github.com/mjbvz/vscode-comment-tagged-templates
+const headerCode = (runtime: string, refresh: string) => /* js */ `
+import * as $$runtime from "${runtime}";
+import * as $$refresh from "${refresh}";
+const $$registry = $$refresh.createHmrRegistry({
+  createElement: $$runtime.createElement,
+  useState: $$runtime.useState,
+  useEffect: $$runtime.useEffect,
+});
+`;
+
+// for vite to detect, source code needs to include the exact "import.meta.hot.accept" expression.
+const FOOTER_CODE_VITE = /* js */ `
+if (import.meta.hot) {
+  $$refresh.setupHmrVite(import.meta.hot, $$registry);
+  () => import.meta.hot.accept();
+}
+`;
+
+const FOOTER_CODE_WEBPACK4 = /* js */ `
+if (module.hot) {
+  $$refresh.setupHmrWebpack(module.hot, $$registry);
+}
+`;

--- a/packages/tiny-refresh/src/transform.ts
+++ b/packages/tiny-refresh/src/transform.ts
@@ -16,12 +16,17 @@ export function hmrTransform(
   const newLines = [...lines];
   const extraCodes: string[] = [];
 
-  for (let i = 0; i < lines.length - 1; i++) {
+  for (let i = 0; i < lines.length; i++) {
     const prevLine = lines[i - 1] || ""; // TODO: it should be "??" but it breaks old webpack.
     const line = lines[i];
-    // TODO: ability to opt out
-    // - per file?
-    // - per component?
+    // disable per file
+    if (line.startsWith("// @hmr-disable-all")) {
+      return;
+    }
+    // disable per component
+    if (prevLine.startsWith("// @hmr-disable")) {
+      continue;
+    }
     if (
       options.autoDetect
         ? line.match(AUTO_DETECT_RE)

--- a/packages/tiny-refresh/src/transform.ts
+++ b/packages/tiny-refresh/src/transform.ts
@@ -19,7 +19,9 @@ export function hmrTransform(
   for (let i = 0; i < lines.length - 1; i++) {
     const prevLine = lines[i - 1] || ""; // TODO: it should be "??" but it breaks old webpack.
     const line = lines[i];
-    // TODO: ability to opt out auto detection via @hmr-skip
+    // TODO: ability to opt out
+    // - per file?
+    // - per component?
     if (
       options.autoDetect
         ? line.match(AUTO_DETECT_RE)

--- a/packages/tiny-refresh/src/transform.ts
+++ b/packages/tiny-refresh/src/transform.ts
@@ -42,10 +42,11 @@ export function hmrTransform(
   ].join("\n");
 }
 
-const COMPONENT_DECL_RE = /(function|let|const)\s*(\w+)/;
+const COMPONENT_DECL_RE = /(function|var|let|const)\s*(\w+)/;
 
 // find identifier from the next line of "@hmr" comment
 //   function SomeComponent
+//   var SomeComponent
 //   let SomeComponent
 //   const SomeComponent (then `const` will be transformed to `let`)
 function transformComponentDecl(line: string): [string, string] | undefined {

--- a/packages/tiny-refresh/src/transform.ts
+++ b/packages/tiny-refresh/src/transform.ts
@@ -93,10 +93,8 @@ function spliceString(
 // re-assigning over function declaration is sketchy but seems to be okay
 // cf. https://eslint.org/docs/latest/rules/no-func-assign
 const wrapCreateHmrComponent = (name: string, remount: boolean) => /* js */ `
-if (typeof ${name} === "function") {
-  var $$tmp_${name} = ${name};
-  ${name} = $$refresh.createHmrComponent($$registry, "${name}", $$tmp_${name}, { remount: ${remount} });
-}
+var $$tmp_${name} = ${name};
+${name} = $$refresh.createHmrComponent($$registry, "${name}", $$tmp_${name}, { remount: ${remount} });
 `;
 
 // /* js */ comment is for https://github.com/mjbvz/vscode-comment-tagged-templates

--- a/packages/tiny-refresh/src/transform.ts
+++ b/packages/tiny-refresh/src/transform.ts
@@ -94,7 +94,7 @@ function spliceString(
 const wrapCreateHmrComponent = (name: string, remount: boolean) => /* js */ `
 if (typeof ${name} === "function") {
   var $$tmp_${name} = ${name};
-  ${name} = $$refresh.createHmrComponent($$registry, $$tmp_${name}, { remount: ${remount} });
+  ${name} = $$refresh.createHmrComponent($$registry, "${name}", $$tmp_${name}, { remount: ${remount} });
 }
 `;
 

--- a/packages/tiny-refresh/src/transform.ts
+++ b/packages/tiny-refresh/src/transform.ts
@@ -19,6 +19,7 @@ export function hmrTransform(
   for (let i = 0; i < lines.length - 1; i++) {
     const prevLine = lines[i - 1] || ""; // TODO: it should be "??" but it breaks old webpack.
     const line = lines[i];
+    // TODO: ability to opt out auto detection via @hmr-skip
     if (
       options.autoDetect
         ? line.match(AUTO_DETECT_RE)

--- a/packages/tiny-refresh/src/transform.ts
+++ b/packages/tiny-refresh/src/transform.ts
@@ -17,7 +17,7 @@ export function hmrTransform(
   const extraCodes: string[] = [];
 
   for (let i = 0; i < lines.length - 1; i++) {
-    const prevLine = lines[i - 1] ?? "";
+    const prevLine = lines[i - 1] || ""; // TODO: it should be "??" but it breaks old webpack.
     const line = lines[i];
     if (
       options.autoDetect
@@ -45,8 +45,8 @@ export function hmrTransform(
   return [
     headerCode(
       options.runtime,
-      options.refreshRuntime ?? "@hiogawa/tiny-refresh",
-      options.debug ?? false
+      options.refreshRuntime || "@hiogawa/tiny-refresh",
+      options.debug || false
     ),
     ...newLines,
     ...extraCodes,

--- a/packages/tiny-refresh/src/transform.ts
+++ b/packages/tiny-refresh/src/transform.ts
@@ -1,7 +1,5 @@
 import { tinyassert } from "@hiogawa/utils";
 
-// based on packages/tiny-react/src/hmr/transform.ts
-
 const PRAGMA_RE = /^\s*\/\/\s*@hmr/g;
 
 interface HmrTransformOptions {

--- a/packages/tiny-refresh/src/transform.ts
+++ b/packages/tiny-refresh/src/transform.ts
@@ -45,7 +45,8 @@ export function hmrTransform(
   return [
     headerCode(
       options.runtime,
-      options.refreshRuntime ?? "@hiogawa/tiny-refresh"
+      options.refreshRuntime ?? "@hiogawa/tiny-refresh",
+      options.debug ?? false
     ),
     ...newLines,
     ...extraCodes,
@@ -99,14 +100,18 @@ if (typeof ${name} === "function") {
 `;
 
 // /* js */ comment is for https://github.com/mjbvz/vscode-comment-tagged-templates
-const headerCode = (runtime: string, refresh: string) => /* js */ `
+const headerCode = (
+  runtime: string,
+  refresh: string,
+  debug: boolean
+) => /* js */ `
 import * as $$runtime from "${runtime}";
 import * as $$refresh from "${refresh}";
 const $$registry = $$refresh.createHmrRegistry({
   createElement: $$runtime.createElement,
   useState: $$runtime.useState,
   useEffect: $$runtime.useEffect,
-});
+}, ${debug});
 `;
 
 // for vite to detect, source code needs to include the exact "import.meta.hot.accept" expression.

--- a/packages/tiny-refresh/src/vite.ts
+++ b/packages/tiny-refresh/src/vite.ts
@@ -7,6 +7,7 @@ export function vitePluginTinyRefresh(options?: {
   runtime?: string;
   refreshRuntime?: string;
   noAutoDetect?: boolean;
+  debug?: boolean;
 }): Plugin {
   // cf. https://github.com/vitejs/vite-plugin-react/blob/2c3330b9aa40d263e50e8359eca481099700ca9e/packages/plugin-react/src/index.ts#L168-L171
   const filter = createFilter(
@@ -29,6 +30,7 @@ export function vitePluginTinyRefresh(options?: {
           runtime: options?.runtime ?? "react",
           refreshRuntime: options?.refreshRuntime,
           autoDetect: !options?.noAutoDetect,
+          debug: options?.debug,
         });
       }
       return;

--- a/packages/tiny-refresh/src/vite.ts
+++ b/packages/tiny-refresh/src/vite.ts
@@ -6,6 +6,7 @@ export function vitePluginTinyRefresh(options?: {
   exclude?: FilterPattern;
   runtime?: string;
   refreshRuntime?: string;
+  noAutoDetect?: boolean;
 }): Plugin {
   // cf. https://github.com/vitejs/vite-plugin-react/blob/2c3330b9aa40d263e50e8359eca481099700ca9e/packages/plugin-react/src/index.ts#L168-L171
   const filter = createFilter(
@@ -16,7 +17,7 @@ export function vitePluginTinyRefresh(options?: {
     name: "@hiogawa/tiny-refresh/react/vite",
     // since esbuild drops comments https://github.com/evanw/esbuild/issues/1439,
     // we need to enforce "pre" to see `// @hmr` comments.
-    // however this means that transform has to handle raw source code e.g. typescript files.
+    // however this means that transform has to handle raw source code e.g. typescript and jsx.
     enforce: "pre",
     apply(_config, env) {
       return env.command === "serve" && !env.ssrBuild;
@@ -27,6 +28,7 @@ export function vitePluginTinyRefresh(options?: {
           bundler: "vite",
           runtime: options?.runtime ?? "react",
           refreshRuntime: options?.refreshRuntime,
+          autoDetect: !options?.noAutoDetect,
         });
       }
       return;

--- a/packages/tiny-refresh/src/vite.ts
+++ b/packages/tiny-refresh/src/vite.ts
@@ -10,7 +10,7 @@ export function vitePluginTinyRefresh(options?: {
 }): Plugin {
   // cf. https://github.com/vitejs/vite-plugin-react/blob/2c3330b9aa40d263e50e8359eca481099700ca9e/packages/plugin-react/src/index.ts#L168-L171
   const filter = createFilter(
-    options?.include ?? /\.[tj]sx?$/,
+    options?.include ?? /\.[tj]sx$/,
     options?.exclude ?? /\/node_modules\//
   );
   return {

--- a/packages/tiny-refresh/src/vite.ts
+++ b/packages/tiny-refresh/src/vite.ts
@@ -1,0 +1,34 @@
+import { type FilterPattern, type Plugin, createFilter } from "vite";
+import { hmrTransform } from "./transform";
+
+// based on packages/tiny-react/src/plugins/vite.ts
+
+export function vitePluginTinyRefresh(options?: {
+  include?: FilterPattern;
+  exclude?: FilterPattern;
+  runtime?: string;
+  refreshRuntime?: string;
+}): Plugin {
+  // cf. https://github.com/vitejs/vite-plugin-react/blob/2c3330b9aa40d263e50e8359eca481099700ca9e/packages/plugin-react/src/index.ts#L168-L171
+  const filter = createFilter(
+    options?.include ?? /\.[tj]sx?$/,
+    options?.exclude ?? /\/node_modules\//
+  );
+  return {
+    name: "@hiogawa/tiny-refresh/react/vite",
+    enforce: "pre",
+    apply(_config, env) {
+      return env.command === "serve" && !env.ssrBuild;
+    },
+    transform(code, id, _options) {
+      if (filter(id)) {
+        return hmrTransform(code, {
+          bundler: "vite",
+          runtime: options?.runtime ?? "react",
+          refreshRuntime: options?.refreshRuntime,
+        });
+      }
+      return;
+    },
+  };
+}

--- a/packages/tiny-refresh/src/vite.ts
+++ b/packages/tiny-refresh/src/vite.ts
@@ -7,7 +7,6 @@ export function vitePluginTinyRefresh(options?: {
   runtime?: string;
   refreshRuntime?: string;
   noAutoDetect?: boolean;
-  debug?: boolean;
 }): Plugin {
   // cf. https://github.com/vitejs/vite-plugin-react/blob/2c3330b9aa40d263e50e8359eca481099700ca9e/packages/plugin-react/src/index.ts#L168-L171
   const filter = createFilter(
@@ -30,7 +29,6 @@ export function vitePluginTinyRefresh(options?: {
           runtime: options?.runtime ?? "react",
           refreshRuntime: options?.refreshRuntime,
           autoDetect: !options?.noAutoDetect,
-          debug: options?.debug,
         });
       }
       return;

--- a/packages/tiny-refresh/src/vite.ts
+++ b/packages/tiny-refresh/src/vite.ts
@@ -14,6 +14,9 @@ export function vitePluginTinyRefresh(options?: {
   );
   return {
     name: "@hiogawa/tiny-refresh/react/vite",
+    // since esbuild drops comments https://github.com/evanw/esbuild/issues/1439,
+    // we need to enforce "pre" to see `// @hmr` comments.
+    // however this means that transform has to handle raw source code e.g. typescript files.
     enforce: "pre",
     apply(_config, env) {
       return env.command === "serve" && !env.ssrBuild;

--- a/packages/tiny-refresh/src/vite.ts
+++ b/packages/tiny-refresh/src/vite.ts
@@ -29,6 +29,7 @@ export function vitePluginTinyRefresh(options?: {
           runtime: options?.runtime ?? "react",
           refreshRuntime: options?.refreshRuntime,
           autoDetect: !options?.noAutoDetect,
+          debug: true,
         });
       }
       return;

--- a/packages/tiny-refresh/src/vite.ts
+++ b/packages/tiny-refresh/src/vite.ts
@@ -1,8 +1,6 @@
 import { type FilterPattern, type Plugin, createFilter } from "vite";
 import { hmrTransform } from "./transform";
 
-// based on packages/tiny-react/src/plugins/vite.ts
-
 export function vitePluginTinyRefresh(options?: {
   include?: FilterPattern;
   exclude?: FilterPattern;

--- a/packages/tiny-refresh/src/webpack.ts
+++ b/packages/tiny-refresh/src/webpack.ts
@@ -6,6 +6,7 @@ export default function tinyRefreshLoader(source: string) {
       bundler: "webpack4",
       runtime: "react",
       autoDetect: true,
+      debug: true,
     }) ?? source
   );
 }

--- a/packages/tiny-refresh/src/webpack.ts
+++ b/packages/tiny-refresh/src/webpack.ts
@@ -2,6 +2,10 @@ import { hmrTransform } from "./transform";
 
 export default (source: string): string => {
   return (
-    hmrTransform(source, { bundler: "webpack4", runtime: "react" }) ?? source
+    hmrTransform(source, {
+      bundler: "webpack4",
+      runtime: "react",
+      autoDetect: true,
+    }) ?? source
   );
 };

--- a/packages/tiny-refresh/src/webpack.ts
+++ b/packages/tiny-refresh/src/webpack.ts
@@ -6,7 +6,6 @@ export default function tinyRefreshLoader(source: string) {
       bundler: "webpack4",
       runtime: "react",
       autoDetect: true,
-      debug: true,
     }) ?? source
   );
 }

--- a/packages/tiny-refresh/src/webpack.ts
+++ b/packages/tiny-refresh/src/webpack.ts
@@ -1,11 +1,12 @@
 import { hmrTransform } from "./transform";
 
-export default (source: string): string => {
+export default function tinyRefreshLoader(source: string) {
   return (
     hmrTransform(source, {
       bundler: "webpack4",
       runtime: "react",
       autoDetect: true,
+      debug: true,
     }) ?? source
   );
-};
+}

--- a/packages/tiny-refresh/src/webpack.ts
+++ b/packages/tiny-refresh/src/webpack.ts
@@ -1,0 +1,7 @@
+import { hmrTransform } from "./transform";
+
+export default (source: string): string => {
+  return (
+    hmrTransform(source, { bundler: "webpack4", runtime: "react" }) ?? source
+  );
+};

--- a/packages/tiny-refresh/tsconfig.json
+++ b/packages/tiny-refresh/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "jsx": "preserve"
+  }
+}

--- a/packages/tiny-refresh/tsup.config.ts
+++ b/packages/tiny-refresh/tsup.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts", "src/vite.ts", "src/webpack.ts"],
+  format: ["esm", "cjs"],
+  dts: true,
+  splitting: false,
+});

--- a/packages/tiny-refresh/vitest.config.ts
+++ b/packages/tiny-refresh/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+  },
+});

--- a/packages/tiny-refresh/vitest.config.ts
+++ b/packages/tiny-refresh/vitest.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
+    dir: "src",
     environment: "jsdom",
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -187,6 +187,24 @@ importers:
         specifier: ^18.17.1
         version: 18.17.1
 
+  packages/tiny-refresh:
+    devDependencies:
+      '@hiogawa/utils':
+        specifier: workspace:*
+        version: link:../utils
+      '@testing-library/react':
+        specifier: ^14.0.0
+        version: 14.0.0(react-dom@18.2.0)(react@18.2.0)
+      '@types/react':
+        specifier: ^18.2.14
+        version: 18.2.14
+      react:
+        specifier: ^18.2.0
+        version: 18.2.0
+      vite:
+        specifier: ^4.4.9
+        version: 4.4.9(@types/node@18.17.1)
+
   packages/tiny-rpc:
     devDependencies:
       '@brillout/json-serializer':
@@ -266,7 +284,7 @@ importers:
         version: 18.2.14
       '@vitejs/plugin-react':
         specifier: ^4.0.1
-        version: 4.0.1(vite@4.4.7)
+        version: 4.0.1(vite@4.4.9)
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -303,7 +321,7 @@ importers:
         version: 18.0.0
       '@vitejs/plugin-react':
         specifier: ^4.0.1
-        version: 4.0.1(vite@4.4.7)
+        version: 4.0.1(vite@4.4.9)
       jsdom:
         specifier: ^22.1.0
         version: 22.1.0
@@ -1906,7 +1924,7 @@ packages:
       chokidar: 3.5.3
       fast-glob: 3.3.1
       magic-string: 0.30.1
-      vite: 4.4.6
+      vite: 4.4.6(@types/node@18.16.20)
     transitivePeerDependencies:
       - rollup
     dev: true
@@ -1921,12 +1939,12 @@ packages:
       '@babel/plugin-transform-react-jsx-self': 7.22.5(@babel/core@7.22.5)
       '@babel/plugin-transform-react-jsx-source': 7.22.5(@babel/core@7.22.5)
       react-refresh: 0.14.0
-      vite: 4.4.6
+      vite: 4.4.6(@types/node@18.16.20)
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@vitejs/plugin-react@4.0.1(vite@4.4.7):
+  /@vitejs/plugin-react@4.0.1(vite@4.4.9):
     resolution: {integrity: sha512-g25lL98essfeSj43HJ0o4DMp0325XK0ITkxpgChzJU/CyemgyChtlxfnRbjfwxDGCTRxTiXtQAsdebQXKMRSOA==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
@@ -1936,7 +1954,7 @@ packages:
       '@babel/plugin-transform-react-jsx-self': 7.22.5(@babel/core@7.22.5)
       '@babel/plugin-transform-react-jsx-source': 7.22.5(@babel/core@7.22.5)
       react-refresh: 0.14.0
-      vite: 4.4.7
+      vite: 4.4.9(@types/node@18.17.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -4344,8 +4362,8 @@ packages:
       fsevents: 2.3.2
     dev: true
 
-  /rollup@3.27.0:
-    resolution: {integrity: sha512-aOltLCrYZ0FhJDm7fCqwTjIUEVjWjcydKBV/Zeid6Mn8BWgDCUBBWT5beM5ieForYNo/1ZHuGJdka26kvQ3Gzg==}
+  /rollup@3.29.4:
+    resolution: {integrity: sha512-oWzmBZwvYrU0iJHtDmhsm662rC15FRXmcjCk1xD771dFDx5jJ02ufAQQTn0etB2emNk4J9EZg/yWKpsn9BWGRw==}
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
     hasBin: true
     optionalDependencies:
@@ -5036,7 +5054,7 @@ packages:
       mlly: 1.4.0
       pathe: 1.1.1
       picocolors: 1.0.0
-      vite: 4.4.6(@types/node@18.17.1)
+      vite: 4.4.9(@types/node@18.17.1)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -5046,41 +5064,6 @@ packages:
       - sugarss
       - supports-color
       - terser
-    dev: true
-
-  /vite@4.4.6:
-    resolution: {integrity: sha512-EY6Mm8vJ++S3D4tNAckaZfw3JwG3wa794Vt70M6cNJ6NxT87yhq7EC8Rcap3ahyHdo8AhCmV9PTk+vG1HiYn1A==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': '>= 14'
-      less: '*'
-      lightningcss: ^1.21.0
-      sass: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-    dependencies:
-      esbuild: 0.18.10
-      postcss: 8.4.27
-      rollup: 3.26.0
-    optionalDependencies:
-      fsevents: 2.3.2
     dev: true
 
   /vite@4.4.6(@types/node@18.16.20):
@@ -5155,8 +5138,8 @@ packages:
       fsevents: 2.3.2
     dev: true
 
-  /vite@4.4.7:
-    resolution: {integrity: sha512-6pYf9QJ1mHylfVh39HpuSfMPojPSKVxZvnclX1K1FyZ1PXDOcLBibdq5t1qxJSnL63ca8Wf4zts6mD8u8oc9Fw==}
+  /vite@4.4.9(@types/node@18.17.1):
+    resolution: {integrity: sha512-2mbUn2LlUmNASWwSCNSJ/EG2HuSRTnVNaydp6vMCm5VIqJsjMfbIWtbH2kDuwUVW5mMUKKZvGPX/rqeqVvv1XA==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
     peerDependencies:
@@ -5183,9 +5166,10 @@ packages:
       terser:
         optional: true
     dependencies:
+      '@types/node': 18.17.1
       esbuild: 0.18.17
       postcss: 8.4.27
-      rollup: 3.27.0
+      rollup: 3.29.4
     optionalDependencies:
       fsevents: 2.3.2
     dev: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -203,7 +203,7 @@ importers:
         version: 18.2.0
       vite:
         specifier: ^4.4.9
-        version: 4.4.9(@types/node@18.17.1)
+        version: 4.4.9(@types/node@20.8.4)
 
   packages/tiny-refresh/examples/react:
     devDependencies:
@@ -222,6 +222,12 @@ importers:
       '@iconify-json/ri':
         specifier: ^1.1.10
         version: 1.1.10
+      '@playwright/test':
+        specifier: ^1.38.1
+        version: 1.38.1
+      '@types/node':
+        specifier: ^20.8.4
+        version: 20.8.4
       '@types/react':
         specifier: ^18.2.14
         version: 18.2.14
@@ -242,7 +248,7 @@ importers:
         version: 0.53.6(postcss@8.4.27)(vite@4.4.9)
       vite:
         specifier: ^4.4.6
-        version: 4.4.9(@types/node@18.17.1)
+        version: 4.4.9(@types/node@20.8.4)
 
   packages/tiny-rpc:
     devDependencies:
@@ -1472,7 +1478,7 @@ packages:
       '@unocss/preset-uno': 0.54.0
       '@unocss/reset': 0.48.5
       local-pkg: 0.4.3
-      unocss: 0.53.6(postcss@8.4.27)(vite@4.4.6)
+      unocss: 0.53.6(postcss@8.4.27)(vite@4.4.9)
     dev: true
 
   /@iconify-json/ri@1.1.10:
@@ -1573,6 +1579,14 @@ packages:
       fastq: 1.15.0
     dev: true
 
+  /@playwright/test@1.38.1:
+    resolution: {integrity: sha512-NqRp8XMwj3AK+zKLbZShl0r/9wKgzqI/527bkptKXomtuo+dOjU9NdMASQ8DNC9z9zLOMbG53T4eihYr3XR+BQ==}
+    engines: {node: '>=16'}
+    hasBin: true
+    dependencies:
+      playwright: 1.38.1
+    dev: true
+
   /@polka/url@1.0.0-next.21:
     resolution: {integrity: sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==}
     dev: true
@@ -1660,7 +1674,7 @@ packages:
   /@types/better-sqlite3@7.6.4:
     resolution: {integrity: sha512-dzrRZCYPXIXfSR1/surNbJ/grU3scTaygS0OMzjlGf71i9sc2fGyHPXXiXmEvNIoE0cGwsanEFMVJxPXmco9Eg==}
     dependencies:
-      '@types/node': 20.5.6
+      '@types/node': 20.8.4
     dev: true
 
   /@types/chai-subset@1.3.3:
@@ -1705,6 +1719,12 @@ packages:
 
   /@types/node@20.5.6:
     resolution: {integrity: sha512-Gi5wRGPbbyOTX+4Y2iULQ27oUPrefaB0PxGQJnfyWN3kvEDGM3mIB5M/gQLmitZf7A9FmLeaqxD3L1CXpm3VKQ==}
+    dev: true
+
+  /@types/node@20.8.4:
+    resolution: {integrity: sha512-ZVPnqU58giiCjSxjVUESDtdPk4QR5WQhhINbc9UBrKLU68MX5BF6kbQzTrkwbolyr0X8ChBpXfavr5mZFKZQ5A==}
+    dependencies:
+      undici-types: 5.25.3
     dev: true
 
   /@types/normalize-package-data@2.4.1:
@@ -1994,7 +2014,7 @@ packages:
       chokidar: 3.5.3
       fast-glob: 3.3.1
       magic-string: 0.30.1
-      vite: 4.4.9(@types/node@18.17.1)
+      vite: 4.4.9(@types/node@20.8.4)
     transitivePeerDependencies:
       - rollup
     dev: true
@@ -2024,7 +2044,7 @@ packages:
       '@babel/plugin-transform-react-jsx-self': 7.22.5(@babel/core@7.22.5)
       '@babel/plugin-transform-react-jsx-source': 7.22.5(@babel/core@7.22.5)
       react-refresh: 0.14.0
-      vite: 4.4.9(@types/node@18.17.1)
+      vite: 4.4.9(@types/node@20.8.4)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -4151,6 +4171,22 @@ packages:
       pathe: 1.1.1
     dev: true
 
+  /playwright-core@1.38.1:
+    resolution: {integrity: sha512-tQqNFUKa3OfMf4b2jQ7aGLB8o9bS3bOY0yMEtldtC2+spf8QXG9zvXLTXUeRsoNuxEYMgLYR+NXfAa1rjKRcrg==}
+    engines: {node: '>=16'}
+    hasBin: true
+    dev: true
+
+  /playwright@1.38.1:
+    resolution: {integrity: sha512-oRMSJmZrOu1FP5iu3UrCx8JEFRIMxLDM0c/3o4bpzU5Tz97BypefWf7TuTNPWeCe279TPal5RtPPZ+9lW/Qkow==}
+    engines: {node: '>=16'}
+    hasBin: true
+    dependencies:
+      playwright-core: 1.38.1
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: true
+
   /postcss-load-config@4.0.1:
     resolution: {integrity: sha512-vEJIc8RdiBRu3oRAI0ymerOn+7rPuMvRXslTvZUKZonDHFIczxztIyJ1urxM1x9JXEikvpWWTUUqal5j/8QgvA==}
     engines: {node: '>= 14'}
@@ -5039,6 +5075,10 @@ packages:
       jiti: 1.19.1
     dev: true
 
+  /undici-types@5.25.3:
+    resolution: {integrity: sha512-Ga1jfYwRn7+cP9v8auvEXN1rX3sWqlayd4HP7OKk4mZWylEmu3KzXDUGrQUN6Ol7qo1gPvB2e5gX6udnyEPgdA==}
+    dev: true
+
   /universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
@@ -5150,7 +5190,7 @@ packages:
       spdx-expression-parse: 3.0.1
     dev: true
 
-  /vite-node@0.32.2(@types/node@18.17.1):
+  /vite-node@0.32.2(@types/node@20.8.4):
     resolution: {integrity: sha512-dTQ1DCLwl2aEseov7cfQ+kDMNJpM1ebpyMMMwWzBvLbis8Nla/6c9WQcqpPssTwS6Rp/+U6KwlIj8Eapw4bLdA==}
     engines: {node: '>=v14.18.0'}
     hasBin: true
@@ -5160,7 +5200,7 @@ packages:
       mlly: 1.4.0
       pathe: 1.1.1
       picocolors: 1.0.0
-      vite: 4.4.9(@types/node@18.17.1)
+      vite: 4.4.9(@types/node@20.8.4)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -5208,7 +5248,7 @@ packages:
       fsevents: 2.3.2
     dev: true
 
-  /vite@4.4.6(@types/node@18.17.1):
+  /vite@4.4.6(@types/node@20.8.4):
     resolution: {integrity: sha512-EY6Mm8vJ++S3D4tNAckaZfw3JwG3wa794Vt70M6cNJ6NxT87yhq7EC8Rcap3ahyHdo8AhCmV9PTk+vG1HiYn1A==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
@@ -5236,7 +5276,7 @@ packages:
       terser:
         optional: true
     dependencies:
-      '@types/node': 18.17.1
+      '@types/node': 20.8.4
       esbuild: 0.18.10
       postcss: 8.4.27
       rollup: 3.26.0
@@ -5244,7 +5284,7 @@ packages:
       fsevents: 2.3.2
     dev: true
 
-  /vite@4.4.9(@types/node@18.17.1):
+  /vite@4.4.9(@types/node@20.8.4):
     resolution: {integrity: sha512-2mbUn2LlUmNASWwSCNSJ/EG2HuSRTnVNaydp6vMCm5VIqJsjMfbIWtbH2kDuwUVW5mMUKKZvGPX/rqeqVvv1XA==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
@@ -5272,7 +5312,7 @@ packages:
       terser:
         optional: true
     dependencies:
-      '@types/node': 18.17.1
+      '@types/node': 20.8.4
       esbuild: 0.18.17
       postcss: 8.4.27
       rollup: 3.29.4
@@ -5313,7 +5353,7 @@ packages:
     dependencies:
       '@types/chai': 4.3.5
       '@types/chai-subset': 1.3.3
-      '@types/node': 18.17.1
+      '@types/node': 20.8.4
       '@vitest/expect': 0.32.2
       '@vitest/runner': 0.32.2
       '@vitest/snapshot': 0.32.2
@@ -5333,8 +5373,8 @@ packages:
       strip-literal: 1.0.1
       tinybench: 2.5.0
       tinypool: 0.5.0
-      vite: 4.4.6(@types/node@18.17.1)
-      vite-node: 0.32.2(@types/node@18.17.1)
+      vite: 4.4.6(@types/node@20.8.4)
+      vite-node: 0.32.2(@types/node@20.8.4)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -205,6 +205,45 @@ importers:
         specifier: ^4.4.9
         version: 4.4.9(@types/node@18.17.1)
 
+  packages/tiny-refresh/examples/react:
+    devDependencies:
+      '@hiogawa/theme-script':
+        specifier: workspace:*
+        version: link:../../../theme-script
+      '@hiogawa/tiny-refresh':
+        specifier: workspace:*
+        version: link:../..
+      '@hiogawa/unocss-preset-antd':
+        specifier: 2.2.1-pre.3
+        version: 2.2.1-pre.3(@unocss/preset-uno@0.54.0)(unocss@0.53.6)
+      '@hiogawa/utils':
+        specifier: workspace:*
+        version: link:../../../utils
+      '@iconify-json/ri':
+        specifier: ^1.1.10
+        version: 1.1.10
+      '@types/react':
+        specifier: ^18.2.14
+        version: 18.2.14
+      '@types/react-dom':
+        specifier: ^18.2.7
+        version: 18.2.7
+      '@vitejs/plugin-react':
+        specifier: ^4.0.1
+        version: 4.0.1(vite@4.4.9)
+      react:
+        specifier: ^18.2.0
+        version: 18.2.0
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.2.0(react@18.2.0)
+      unocss:
+        specifier: ^0.53.6
+        version: 0.53.6(postcss@8.4.27)(vite@4.4.9)
+      vite:
+        specifier: ^4.4.6
+        version: 4.4.9(@types/node@18.17.1)
+
   packages/tiny-rpc:
     devDependencies:
       '@brillout/json-serializer':
@@ -1715,6 +1754,17 @@ packages:
       - vite
     dev: true
 
+  /@unocss/astro@0.53.6(vite@4.4.9):
+    resolution: {integrity: sha512-RA0H8iujvMhH7ga6RWOzzdtNRP8qB++1eu7ffajJTktih6xYXh1I5lRR9uYajW2riShhtMQ7FXLRnlEIa1Vwog==}
+    dependencies:
+      '@unocss/core': 0.53.6
+      '@unocss/reset': 0.53.6
+      '@unocss/vite': 0.53.6(vite@4.4.9)
+    transitivePeerDependencies:
+      - rollup
+      - vite
+    dev: true
+
   /@unocss/cli@0.53.6:
     resolution: {integrity: sha512-igUdBRT2cNreuT/8LKJp+0D6Sj+NQADs2fj1auPrh9Z6lOk0Ot8mY2hnKzdszHUosoOgdGyy8pLiAtQ09TFtRA==}
     engines: {node: '>=14'}
@@ -1925,6 +1975,26 @@ packages:
       fast-glob: 3.3.1
       magic-string: 0.30.1
       vite: 4.4.6(@types/node@18.16.20)
+    transitivePeerDependencies:
+      - rollup
+    dev: true
+
+  /@unocss/vite@0.53.6(vite@4.4.9):
+    resolution: {integrity: sha512-EfbtSqozWC8NVG0P+x02k6L77cEr0H/bfVtEtvwLIrzSyLoVU/Z+li248cB7v8ZSDQXYKJe9uiItx/GTc04A4g==}
+    peerDependencies:
+      vite: ^2.9.0 || ^3.0.0-0 || ^4.0.0
+    dependencies:
+      '@ampproject/remapping': 2.2.1
+      '@rollup/pluginutils': 5.0.2
+      '@unocss/config': 0.53.6
+      '@unocss/core': 0.53.6
+      '@unocss/inspector': 0.53.6
+      '@unocss/scope': 0.53.6
+      '@unocss/transformer-directives': 0.53.6
+      chokidar: 3.5.3
+      fast-glob: 3.3.1
+      magic-string: 0.30.1
+      vite: 4.4.9(@types/node@18.17.1)
     transitivePeerDependencies:
       - rollup
     dev: true
@@ -5008,6 +5078,42 @@ packages:
       '@unocss/transformer-directives': 0.53.6
       '@unocss/transformer-variant-group': 0.53.6
       '@unocss/vite': 0.53.6(vite@4.4.6)
+    transitivePeerDependencies:
+      - postcss
+      - rollup
+      - supports-color
+      - vite
+    dev: true
+
+  /unocss@0.53.6(postcss@8.4.27)(vite@4.4.9):
+    resolution: {integrity: sha512-yZeSaa3ulfDyU7WaOeN5AZN/ciopY+f9GPuME4hgzxZmUnCSJmuwBW+5UHud2BSRKdem+mLIpBzNXTOsDP8gFA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@unocss/webpack': 0.53.6
+    peerDependenciesMeta:
+      '@unocss/webpack':
+        optional: true
+    dependencies:
+      '@unocss/astro': 0.53.6(vite@4.4.9)
+      '@unocss/cli': 0.53.6
+      '@unocss/core': 0.53.6
+      '@unocss/extractor-arbitrary-variants': 0.53.6
+      '@unocss/postcss': 0.53.6(postcss@8.4.27)
+      '@unocss/preset-attributify': 0.53.6
+      '@unocss/preset-icons': 0.53.6
+      '@unocss/preset-mini': 0.53.6
+      '@unocss/preset-tagify': 0.53.6
+      '@unocss/preset-typography': 0.53.6
+      '@unocss/preset-uno': 0.53.6
+      '@unocss/preset-web-fonts': 0.53.6
+      '@unocss/preset-wind': 0.53.6
+      '@unocss/reset': 0.53.6
+      '@unocss/transformer-attributify-jsx': 0.53.6
+      '@unocss/transformer-attributify-jsx-babel': 0.53.6
+      '@unocss/transformer-compile-class': 0.53.6
+      '@unocss/transformer-directives': 0.53.6
+      '@unocss/transformer-variant-group': 0.53.6
+      '@unocss/vite': 0.53.6(vite@4.4.9)
     transitivePeerDependencies:
       - postcss
       - rollup

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,4 @@ packages:
   - packages/*
   - packages/tiny-sql/examples/*
   - packages/theme-script/examples/*
+  - packages/tiny-refresh/examples/*


### PR DESCRIPTION
Extracted from https://github.com/hi-ogawa/js-utils/pull/152 by

```sh
git checkout feat-tiny-refresh -- packages/tiny-refresh
```

since this seems to be useful before waiting `tiny-react` to finish (and also `tiny-react` will get dedicated repository?)

## ideas/todo

- [x] react/vite example
- [x] ~`autoRegex` option to detect automatically but make it customizable~ auto detect by regexp
- [x] no full reload for "unsafe" toggle
- [x] e2e

## bug

- [x] child file's invalidate doesn't trigger reload? (EDIT: fix in https://github.com/hi-ogawa/js-utils/pull/153/commits/8561def1fb1b4a550cc40a825d706ef31678c1d6)
  - logic is similar to solid-refresh so does it reproduce there?
    - it looks like solid does "invalidate" twice to handle this naturally.
      For example, when some components are removed, "invalidate" happens on this removal, then after changed other component, it will cause "invalidate" again which affects the parent component.
  - vite-plugin-react has debounce, so it might be doing some trick? or probably they have global registry anyway so easier to force refresh parents?

```
// invalidate other-file.tsx
오후 1:01:19 [vite] hmr update /src/other-file.tsx
오후 1:01:19 [vite] hmr invalidate /src/other-file.tsx
오후 1:01:19 [vite] hmr update /src/app.tsx              /// <-- accepted by parent and not trigger reload?

// invalidate app.tsx
오후 1:02:19 [vite] hmr update /src/app.tsx
오후 1:02:19 [vite] hmr invalidate /src/app.tsx
오후 1:02:19 [vite] page reload src/app.tsx             /// <-- this leads to full-reload
```
