### PR TITLE
test: skip tiny-refresh e2e on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,5 @@ jobs:
       - run: pnpm lint-check
       - run: pnpm build
       - run: pnpm tsc
-      - run: pnpm exec playwright install chromium
       - run: pnpm test
       - run: npx typedoc

--- a/packages/tiny-refresh/examples/react/package.json
+++ b/packages/tiny-refresh/examples/react/package.json
@@ -4,7 +4,6 @@
   "scripts": {
     "dev": "vite dev",
     "build": "vite build",
-    "test": "pnpm -s test-e2e",
     "test-e2e": "playwright test"
   },
   "devDependencies": {


### PR DESCRIPTION
- partially revert https://github.com/hi-ogawa/js-utils/pull/155

It looked fine at first but it seems it's super flaky, so let's revert it for now...