### PR TITLE
perf(tiny-react): optimize vnode format

### DIFF
--- a/packages/tiny-react/src/helper/hyperscript.test.ts
+++ b/packages/tiny-react/src/helper/hyperscript.test.ts
@@ -27,37 +27,37 @@ describe("hyperscript", () => {
               "key": "abc",
               "props": {
                 "children": {
-                  "type": "empty",
+                  "type": Symbol(empty),
                 },
                 "value": "hello",
               },
               "render": [Function],
-              "type": "custom",
+              "type": Symbol(custom),
             },
             {
-              "type": "empty",
+              "type": Symbol(empty),
             },
             {
               "data": "0",
-              "type": "text",
+              "type": Symbol(text),
             },
             {
               "key": undefined,
               "props": {
                 "children": {
-                  "type": "empty",
+                  "type": Symbol(empty),
                 },
               },
               "render": [Function],
-              "type": "custom",
+              "type": Symbol(custom),
             },
             {
-              "type": "empty",
+              "type": Symbol(empty),
             },
             {
               "child": {
                 "data": "world",
-                "type": "text",
+                "type": Symbol(text),
               },
               "key": 0,
               "name": "span",
@@ -65,41 +65,41 @@ describe("hyperscript", () => {
                 "className": "text-red",
               },
               "ref": [Function],
-              "type": "tag",
+              "type": Symbol(tag),
             },
             {
               "child": {
                 "data": "0",
-                "type": "text",
+                "type": Symbol(text),
               },
               "key": undefined,
               "name": "span",
               "props": {},
               "ref": undefined,
-              "type": "tag",
+              "type": Symbol(tag),
             },
             {
               "child": {
                 "children": [
                   {
                     "data": "0",
-                    "type": "text",
+                    "type": Symbol(text),
                   },
                   {
                     "data": "1",
-                    "type": "text",
+                    "type": Symbol(text),
                   },
                 ],
-                "type": "fragment",
+                "type": Symbol(fragment),
               },
               "key": undefined,
               "name": "span",
               "props": {},
               "ref": undefined,
-              "type": "tag",
+              "type": Symbol(tag),
             },
           ],
-          "type": "fragment",
+          "type": Symbol(fragment),
         },
         "key": undefined,
         "name": "div",
@@ -107,7 +107,7 @@ describe("hyperscript", () => {
           "className": "flex",
         },
         "ref": undefined,
-        "type": "tag",
+        "type": Symbol(tag),
       }
     `);
   });

--- a/packages/tiny-react/src/helper/hyperscript.ts
+++ b/packages/tiny-react/src/helper/hyperscript.ts
@@ -1,5 +1,9 @@
 import {
   EMPTY_VNODE,
+  NODE_TYPE_CUSTOM,
+  NODE_TYPE_FRAGMENT,
+  NODE_TYPE_TAG,
+  NODE_TYPE_TEXT,
   type NodeKey,
   type Props,
   type VNode,
@@ -32,7 +36,7 @@ export function createElement(
   if (typeof tag === "string") {
     const { ref, ...propsNoKeyNoRef } = propsNoKey as { ref?: any };
     return {
-      type: "tag",
+      type: NODE_TYPE_TAG,
       name: tag,
       key,
       ref,
@@ -41,7 +45,7 @@ export function createElement(
     };
   } else if (typeof tag === "function") {
     return {
-      type: "custom",
+      type: NODE_TYPE_CUSTOM,
       key,
       props: {
         ...propsNoKey,
@@ -62,7 +66,7 @@ export function Fragment(props: { children?: ComponentChildren }): VNode {
 function normalizeComponentChildren(children?: ComponentChildren): VNode {
   if (Array.isArray(children)) {
     return {
-      type: "fragment",
+      type: NODE_TYPE_FRAGMENT,
       children: children.map((c) => normalizeComponentChildren(c)),
     };
   }
@@ -80,7 +84,7 @@ function normalizeComponentChild(child: ComponentChild): VNode {
   }
   if (typeof child === "string" || typeof child === "number") {
     return {
-      type: "text",
+      type: NODE_TYPE_TEXT,
       data: String(child),
     };
   }

--- a/packages/tiny-react/src/index.test.ts
+++ b/packages/tiny-react/src/index.test.ts
@@ -45,14 +45,14 @@ describe(render, () => {
               "data": "hello",
               "hnode": hello,
               "parent": [Circular],
-              "type": "text",
+              "type": Symbol(text),
             },
             {
               "child": {
                 "data": "world",
                 "hnode": world,
                 "parent": [Circular],
-                "type": "text",
+                "type": Symbol(text),
               },
               "hnode": <span
                 class="text-red"
@@ -67,7 +67,7 @@ describe(render, () => {
                 "className": "text-red",
               },
               "ref": undefined,
-              "type": "tag",
+              "type": Symbol(tag),
             },
           ],
           "parent": [Circular],
@@ -76,7 +76,7 @@ describe(render, () => {
           >
             world
           </span>,
-          "type": "fragment",
+          "type": Symbol(fragment),
         },
         "hnode": <div
           class="flex items-center gap-2"
@@ -95,7 +95,7 @@ describe(render, () => {
           "className": "flex items-center gap-2",
         },
         "ref": undefined,
-        "type": "tag",
+        "type": Symbol(tag),
       }
     `);
     vnode = h.div({ className: "flex items-center gap-2" }, "reconcile");
@@ -115,7 +115,7 @@ describe(render, () => {
           "data": "reconcile",
           "hnode": reconcile,
           "parent": [Circular],
-          "type": "text",
+          "type": Symbol(text),
         },
         "hnode": <div
           class="flex items-center gap-2"
@@ -129,7 +129,7 @@ describe(render, () => {
           "className": "flex items-center gap-2",
         },
         "ref": undefined,
-        "type": "tag",
+        "type": Symbol(tag),
       }
     `);
   });
@@ -162,7 +162,7 @@ describe(render, () => {
                   "data": "hello",
                   "hnode": hello,
                   "parent": [Circular],
-                  "type": "text",
+                  "type": Symbol(text),
                 },
                 "hnode": <span>
                   hello
@@ -173,18 +173,18 @@ describe(render, () => {
                 "parent": [Circular],
                 "props": {},
                 "ref": undefined,
-                "type": "tag",
+                "type": Symbol(tag),
               },
               {
                 "data": "world",
                 "hnode": world,
                 "parent": [Circular],
-                "type": "text",
+                "type": Symbol(text),
               },
             ],
             "parent": [Circular],
             "slot": world,
-            "type": "fragment",
+            "type": Symbol(fragment),
           },
           "hnode": <div>
             <span>
@@ -198,7 +198,7 @@ describe(render, () => {
           "parent": [Circular],
           "props": {},
           "ref": undefined,
-          "type": "tag",
+          "type": Symbol(tag),
         },
         "hookContext": HookContext {
           "hookCount": 0,
@@ -219,7 +219,7 @@ describe(render, () => {
         "key": undefined,
         "props": {
           "children": {
-            "type": "empty",
+            "type": Symbol(empty),
           },
           "value": "hello",
         },
@@ -230,7 +230,7 @@ describe(render, () => {
           </span>
           world
         </div>,
-        "type": "custom",
+        "type": Symbol(custom),
       }
     `);
   });

--- a/packages/tiny-react/src/virtual-dom.ts
+++ b/packages/tiny-react/src/virtual-dom.ts
@@ -12,6 +12,14 @@ export type HNode = Node;
 export type HTag = Element;
 export type HText = Text;
 
+// node type (use symbol for debuggability?)
+// TODO: perf between string, number, symbol
+export const NODE_TYPE_EMPTY = Symbol.for("empty");
+export const NODE_TYPE_TAG = Symbol.for("tag");
+export const NODE_TYPE_TEXT = Symbol.for("text");
+export const NODE_TYPE_CUSTOM = Symbol.for("custom");
+export const NODE_TYPE_FRAGMENT = Symbol.for("fragment");
+
 //
 // virtual node (immutable)
 //
@@ -21,12 +29,12 @@ export type VNode = VEmpty | VTag | VText | VCustom | VFragment;
 
 // TODO: safe to optmize into singleton constant?
 export type VEmpty = {
-  type: "empty";
+  type: typeof NODE_TYPE_EMPTY;
 };
 
 // dom element
 export type VTag = {
-  type: "tag";
+  type: typeof NODE_TYPE_TAG;
   key?: NodeKey;
   name: string; // tagName
   props: Props;
@@ -36,20 +44,20 @@ export type VTag = {
 
 // text node
 export type VText = {
-  type: "text";
+  type: typeof NODE_TYPE_TEXT;
   data: string;
 };
 
 // user-defined functional component
 export type VCustom = {
-  type: "custom";
+  type: typeof NODE_TYPE_CUSTOM;
   key?: NodeKey;
   props: Props;
   render: (props: Props) => VNode;
 };
 
 export type VFragment = {
-  type: "fragment";
+  type: typeof NODE_TYPE_FRAGMENT;
   key?: NodeKey;
   children: VNode[];
 };
@@ -96,7 +104,7 @@ export type BFragment = Omit<VFragment, "children"> & {
 
 export function emptyNode(): VNode & BNode {
   return {
-    type: "empty",
+    type: NODE_TYPE_EMPTY,
   };
 }
 
@@ -104,14 +112,14 @@ export function emptyNode(): VNode & BNode {
 //       for now, this would be critical to not break `memo(Component)` shallow equal with empty children.
 //       ideally, we could VNode to accomodate `null | string | number` primitives...
 export const EMPTY_VNODE: VEmpty = {
-  type: "empty",
+  type: NODE_TYPE_EMPTY,
 };
 
 export function getNodeKey(node: VNode | BNode): NodeKey | undefined {
   if (
-    node.type === "tag" ||
-    node.type === "custom" ||
-    node.type === "fragment"
+    node.type === NODE_TYPE_TAG ||
+    node.type === NODE_TYPE_CUSTOM ||
+    node.type === NODE_TYPE_FRAGMENT
   ) {
     return node.key;
   }
@@ -120,10 +128,10 @@ export function getNodeKey(node: VNode | BNode): NodeKey | undefined {
 
 // "slot" is the last HNode inside the BNode subtree
 export function getSlot(node: BNode): HNode | undefined {
-  if (node.type === "empty") {
+  if (node.type === NODE_TYPE_EMPTY) {
     return;
   }
-  if (node.type === "tag" || node.type === "text") {
+  if (node.type === NODE_TYPE_TAG || node.type === NODE_TYPE_TEXT) {
     return node.hnode;
   }
   return node.slot;


### PR DESCRIPTION
Hopefully there are some low hanging perf opportunity here...

- [ ] node type constants from string to symbol or number? (e.g. `"tag" => Symbol.for("tag")`)
- [ ] accommodate primitive value as `VNode` e.g. 
  - replace `type VEmpty, VText` with `VPrimitive= null | string | ...`.
- [ ] replace `BEmpty` with `null`