### PR TITLE
refactor(tiny-react): keep reference from `BNode` to `VNode`

### DIFF
--- a/packages/tiny-react/src/compat/index.ts
+++ b/packages/tiny-react/src/compat/index.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "../hooks";
 import { render } from "../reconciler";
-import { type BNode, type FC, type VNode, emptyNode } from "../virtual-dom";
+import { type BNode, EMPTY_VNODE, type FC, type VNode } from "../virtual-dom";
 
 // non comprehensive compatibility features
 
@@ -33,7 +33,7 @@ export function createRoot(container: Element) {
       bnode = render(vnode, container, bnode);
     },
     unmount() {
-      render(emptyNode(), container, bnode);
+      render(EMPTY_VNODE, container, bnode);
     },
   };
 }

--- a/packages/tiny-react/src/index.test.ts
+++ b/packages/tiny-react/src/index.test.ts
@@ -42,32 +42,45 @@ describe(render, () => {
         "child": {
           "children": [
             {
-              "data": "hello",
               "hnode": hello,
               "parent": [Circular],
               "type": "text",
+              "vnode": {
+                "data": "hello",
+                "type": "text",
+              },
             },
             {
               "child": {
-                "data": "world",
                 "hnode": world,
                 "parent": [Circular],
                 "type": "text",
+                "vnode": {
+                  "data": "world",
+                  "type": "text",
+                },
               },
               "hnode": <span
                 class="text-red"
               >
                 world
               </span>,
-              "key": undefined,
               "listeners": Map {},
-              "name": "span",
               "parent": [Circular],
-              "props": {
-                "className": "text-red",
-              },
-              "ref": undefined,
               "type": "tag",
+              "vnode": {
+                "child": {
+                  "data": "world",
+                  "type": "text",
+                },
+                "key": undefined,
+                "name": "span",
+                "props": {
+                  "className": "text-red",
+                },
+                "ref": undefined,
+                "type": "tag",
+              },
             },
           ],
           "parent": [Circular],
@@ -77,6 +90,28 @@ describe(render, () => {
             world
           </span>,
           "type": "fragment",
+          "vnode": {
+            "children": [
+              {
+                "data": "hello",
+                "type": "text",
+              },
+              {
+                "child": {
+                  "data": "world",
+                  "type": "text",
+                },
+                "key": undefined,
+                "name": "span",
+                "props": {
+                  "className": "text-red",
+                },
+                "ref": undefined,
+                "type": "tag",
+              },
+            ],
+            "type": "fragment",
+          },
         },
         "hnode": <div
           class="flex items-center gap-2"
@@ -88,14 +123,40 @@ describe(render, () => {
             world
           </span>
         </div>,
-        "key": undefined,
         "listeners": Map {},
-        "name": "div",
-        "props": {
-          "className": "flex items-center gap-2",
-        },
-        "ref": undefined,
+        "parent": undefined,
         "type": "tag",
+        "vnode": {
+          "child": {
+            "children": [
+              {
+                "data": "hello",
+                "type": "text",
+              },
+              {
+                "child": {
+                  "data": "world",
+                  "type": "text",
+                },
+                "key": undefined,
+                "name": "span",
+                "props": {
+                  "className": "text-red",
+                },
+                "ref": undefined,
+                "type": "tag",
+              },
+            ],
+            "type": "fragment",
+          },
+          "key": undefined,
+          "name": "div",
+          "props": {
+            "className": "flex items-center gap-2",
+          },
+          "ref": undefined,
+          "type": "tag",
+        },
       }
     `);
     vnode = h.div({ className: "flex items-center gap-2" }, "reconcile");
@@ -112,24 +173,35 @@ describe(render, () => {
     expect(bnode).toMatchInlineSnapshot(`
       {
         "child": {
-          "data": "reconcile",
           "hnode": reconcile,
           "parent": [Circular],
           "type": "text",
+          "vnode": {
+            "data": "reconcile",
+            "type": "text",
+          },
         },
         "hnode": <div
           class="flex items-center gap-2"
         >
           reconcile
         </div>,
-        "key": undefined,
         "listeners": Map {},
-        "name": "div",
-        "props": {
-          "className": "flex items-center gap-2",
-        },
-        "ref": undefined,
+        "parent": undefined,
         "type": "tag",
+        "vnode": {
+          "child": {
+            "data": "reconcile",
+            "type": "text",
+          },
+          "key": undefined,
+          "name": "div",
+          "props": {
+            "className": "flex items-center gap-2",
+          },
+          "ref": undefined,
+          "type": "tag",
+        },
       }
     `);
   });
@@ -159,32 +231,65 @@ describe(render, () => {
             "children": [
               {
                 "child": {
-                  "data": "hello",
                   "hnode": hello,
                   "parent": [Circular],
                   "type": "text",
+                  "vnode": {
+                    "data": "hello",
+                    "type": "text",
+                  },
                 },
                 "hnode": <span>
                   hello
                 </span>,
-                "key": undefined,
                 "listeners": Map {},
-                "name": "span",
                 "parent": [Circular],
-                "props": {},
-                "ref": undefined,
                 "type": "tag",
+                "vnode": {
+                  "child": {
+                    "data": "hello",
+                    "type": "text",
+                  },
+                  "key": undefined,
+                  "name": "span",
+                  "props": {},
+                  "ref": undefined,
+                  "type": "tag",
+                },
               },
               {
-                "data": "world",
                 "hnode": world,
                 "parent": [Circular],
                 "type": "text",
+                "vnode": {
+                  "data": "world",
+                  "type": "text",
+                },
               },
             ],
             "parent": [Circular],
             "slot": world,
             "type": "fragment",
+            "vnode": {
+              "children": [
+                {
+                  "child": {
+                    "data": "hello",
+                    "type": "text",
+                  },
+                  "key": undefined,
+                  "name": "span",
+                  "props": {},
+                  "ref": undefined,
+                  "type": "tag",
+                },
+                {
+                  "data": "world",
+                  "type": "text",
+                },
+              ],
+              "type": "fragment",
+            },
           },
           "hnode": <div>
             <span>
@@ -192,13 +297,36 @@ describe(render, () => {
             </span>
             world
           </div>,
-          "key": undefined,
           "listeners": Map {},
-          "name": "div",
           "parent": [Circular],
-          "props": {},
-          "ref": undefined,
           "type": "tag",
+          "vnode": {
+            "child": {
+              "children": [
+                {
+                  "child": {
+                    "data": "hello",
+                    "type": "text",
+                  },
+                  "key": undefined,
+                  "name": "span",
+                  "props": {},
+                  "ref": undefined,
+                  "type": "tag",
+                },
+                {
+                  "data": "world",
+                  "type": "text",
+                },
+              ],
+              "type": "fragment",
+            },
+            "key": undefined,
+            "name": "div",
+            "props": {},
+            "ref": undefined,
+            "type": "tag",
+          },
         },
         "hookContext": HookContext {
           "hookCount": 0,
@@ -216,14 +344,7 @@ describe(render, () => {
             world
           </div>
         </main>,
-        "key": undefined,
-        "props": {
-          "children": {
-            "type": "empty",
-          },
-          "value": "hello",
-        },
-        "render": [Function],
+        "parent": undefined,
         "slot": <div>
           <span>
             hello
@@ -231,6 +352,17 @@ describe(render, () => {
           world
         </div>,
         "type": "custom",
+        "vnode": {
+          "key": undefined,
+          "props": {
+            "children": {
+              "type": "empty",
+            },
+            "value": "hello",
+          },
+          "render": [Function],
+          "type": "custom",
+        },
       }
     `);
   });

--- a/packages/tiny-react/src/reconciler.ts
+++ b/packages/tiny-react/src/reconciler.ts
@@ -16,16 +16,17 @@ import {
   type Props,
   type VCustom,
   type VNode,
-  emptyNode,
+  emptyBNode,
+  getBNodeKey,
   getBNodeSlot,
-  getNodeKey,
+  getVNodeKey,
 } from "./virtual-dom";
 
 export function render(vnode: VNode, parent: HNode, bnode?: BNode) {
   const effectManager = new EffectManager();
   const newBnode = reconcileNode(
     vnode,
-    bnode ?? emptyNode(),
+    bnode ?? emptyBNode(),
     parent,
     undefined,
     effectManager
@@ -46,17 +47,17 @@ function reconcileNode(
     if (bnode.type === NODE_TYPE_EMPTY) {
     } else {
       unmount(bnode);
-      bnode = emptyNode();
+      bnode = emptyBNode();
     }
   } else if (vnode.type === NODE_TYPE_TAG) {
     if (
       bnode.type === NODE_TYPE_TAG &&
-      bnode.key === vnode.key &&
-      bnode.ref === vnode.ref &&
-      bnode.name === vnode.name
+      bnode.vnode.key === vnode.key &&
+      bnode.vnode.ref === vnode.ref &&
+      bnode.vnode.name === vnode.name
     ) {
-      reconcileTagProps(bnode, vnode.props, bnode.props);
-      bnode.props = vnode.props;
+      reconcileTagProps(bnode, vnode.props, bnode.vnode.props);
+      bnode.vnode = vnode;
       bnode.child = reconcileNode(
         vnode.child,
         bnode.child,
@@ -70,12 +71,19 @@ function reconcileNode(
       const hnode = document.createElement(vnode.name);
       const child = reconcileNode(
         vnode.child,
-        emptyNode(),
+        emptyBNode(),
         hnode,
         undefined,
         effectManager
       );
-      bnode = { ...vnode, child, hnode, listeners: new Map() } satisfies BTag;
+      bnode = {
+        type: vnode.type,
+        vnode,
+        child,
+        hnode,
+        listeners: new Map(),
+        parent: undefined,
+      } satisfies BTag;
       reconcileTagProps(bnode, vnode.props, {});
       placeChild(bnode.hnode, hparent, preSlot, true);
       effectManager.refNodes.push(bnode);
@@ -83,15 +91,20 @@ function reconcileNode(
     bnode.child.parent = bnode;
   } else if (vnode.type === NODE_TYPE_TEXT) {
     if (bnode.type === NODE_TYPE_TEXT) {
-      if (bnode.data !== vnode.data) {
+      if (bnode.vnode.data !== vnode.data) {
         bnode.hnode.data = vnode.data;
-        bnode.data = vnode.data;
       }
+      bnode.vnode = vnode;
       placeChild(bnode.hnode, hparent, preSlot, false);
     } else {
       unmount(bnode);
       const hnode = document.createTextNode(vnode.data);
-      bnode = { ...vnode, hnode } satisfies BText;
+      bnode = {
+        type: vnode.type,
+        vnode,
+        hnode,
+        parent: undefined,
+      } satisfies BText;
       placeChild(bnode.hnode, hparent, preSlot, true);
     }
   } else if (vnode.type === NODE_TYPE_FRAGMENT) {
@@ -99,7 +112,7 @@ function reconcileNode(
     // https://github.com/yewstack/yew/blob/30e2d548ef57a4b738fb285251b986467ef7eb95/packages/yew/src/dom_bundle/blist.rs#L416
     // https://github.com/snabbdom/snabbdom/blob/420fa78abe98440d24e2c5af2f683e040409e0a6/src/init.ts#L289
     // https://github.com/WebReflection/udomdiff/blob/8923d4fac63a40c72006a46eb0af7bfb5fdef282/index.js
-    if (bnode.type === NODE_TYPE_FRAGMENT && bnode.key === vnode.key) {
+    if (bnode.type === NODE_TYPE_FRAGMENT && bnode.vnode.key === vnode.key) {
       const [newChildren, oldChildren] = alignChildrenByKey(
         vnode.children,
         bnode.children
@@ -108,9 +121,16 @@ function reconcileNode(
       for (const bnode of oldChildren) {
         unmount(bnode);
       }
+      bnode.vnode = vnode;
     } else {
       unmount(bnode);
-      bnode = { ...vnode, children: [] } satisfies BFragment;
+      bnode = {
+        type: vnode.type,
+        vnode,
+        children: [],
+        parent: undefined,
+        slot: undefined,
+      } satisfies BFragment;
     }
     // unmount excess bnode.children
     const bchildren = bnode.children;
@@ -122,7 +142,7 @@ function reconcileNode(
     for (let i = 0; i < vnode.children.length; i++) {
       const bchild = reconcileNode(
         vnode.children[i],
-        bchildren[i] ?? emptyNode(),
+        bchildren[i] ?? emptyBNode(),
         hparent,
         preSlot,
         effectManager
@@ -135,8 +155,8 @@ function reconcileNode(
   } else if (vnode.type === NODE_TYPE_CUSTOM) {
     if (
       bnode.type === NODE_TYPE_CUSTOM &&
-      bnode.key === vnode.key &&
-      bnode.render === vnode.render
+      bnode.vnode.key === vnode.key &&
+      bnode.vnode.render === vnode.render
     ) {
       bnode.hookContext.notify = updateCustomNodeUnsupported;
       const vchild = bnode.hookContext.wrap(() => vnode.render(vnode.props));
@@ -147,19 +167,27 @@ function reconcileNode(
         preSlot,
         effectManager
       );
-      bnode.props = vnode.props;
+      bnode.vnode = vnode;
     } else {
       unmount(bnode);
       const hookContext = new HookContext(updateCustomNodeUnsupported);
       const vchild = hookContext.wrap(() => vnode.render(vnode.props));
       const child = reconcileNode(
         vchild,
-        emptyNode(),
+        emptyBNode(),
         hparent,
         preSlot,
         effectManager
       );
-      bnode = { ...vnode, child, hookContext } satisfies BCustom;
+      bnode = {
+        type: vnode.type,
+        vnode,
+        child,
+        hookContext,
+        hparent: undefined,
+        parent: undefined,
+        slot: undefined,
+      } satisfies BCustom;
     }
     bnode.hparent = hparent;
     bnode.child.parent = bnode;
@@ -287,7 +315,7 @@ function alignChildrenByKey(
   const keyMap = new Map<NodeKey, number>();
 
   vnodes.forEach((vnode, i) => {
-    const key = getNodeKey(vnode);
+    const key = getVNodeKey(vnode);
     if (typeof key !== "undefined") {
       keyMap.set(key, i);
     }
@@ -298,11 +326,11 @@ function alignChildrenByKey(
     return [bnodes, []];
   }
 
-  const newBnodes = vnodes.map(() => emptyNode());
+  const newBnodes: BNode[] = vnodes.map(() => emptyBNode());
   const oldBnodes: BNode[] = [];
 
   for (const bnode of bnodes) {
-    const key = getNodeKey(bnode);
+    const key = getBNodeKey(bnode);
     if (typeof key !== "undefined") {
       const i = keyMap.get(key);
       if (typeof i !== "undefined") {
@@ -381,7 +409,7 @@ function unmountNode(bnode: BNode, skipRemove: boolean) {
     unmountNode(bnode.child, /* skipRemove */ true);
     if (!skipRemove) {
       bnode.hnode.remove();
-      bnode.ref?.(null);
+      bnode.vnode.ref?.(null);
     }
   } else if (bnode.type === NODE_TYPE_TEXT) {
     bnode.hnode.remove();
@@ -408,8 +436,8 @@ class EffectManager {
   run() {
     // TODO: node could be already unmounted?
     for (const tagNode of this.refNodes) {
-      if (tagNode.ref) {
-        tagNode.ref(tagNode.hnode);
+      if (tagNode.vnode.ref) {
+        tagNode.vnode.ref(tagNode.hnode);
       }
     }
 

--- a/packages/tiny-react/src/virtual-dom.ts
+++ b/packages/tiny-react/src/virtual-dom.ts
@@ -70,25 +70,32 @@ export type BNode = BEmpty | BTag | BText | BCustom | BFragment;
 
 export type BNodeParent = BTag | BCustom | BFragment;
 
-export type BEmpty = VEmpty & {
+export type BEmpty = {
+  type: typeof NODE_TYPE_EMPTY;
   // not needed since only we need to traverse up only from BCustom?
   // but for now, make it easier by having uniform `BNode.parent` type
   parent?: BNodeParent;
 };
 
-export type BTag = Omit<VTag, "child"> & {
+export type BTag = {
+  type: typeof NODE_TYPE_TAG;
+  vnode: VTag;
   parent?: BNodeParent;
   child: BNode;
   hnode: HTag;
   listeners: Map<string, () => void>;
 };
 
-export type BText = VText & {
+export type BText = {
+  type: typeof NODE_TYPE_TEXT;
+  vnode: VText;
   parent?: BNodeParent;
   hnode: HText;
 };
 
-export type BCustom = VCustom & {
+export type BCustom = {
+  type: typeof NODE_TYPE_CUSTOM;
+  vnode: VCustom;
   parent?: BNodeParent;
   child: BNode;
   slot?: HNode;
@@ -96,15 +103,18 @@ export type BCustom = VCustom & {
   hookContext: HookContext;
 };
 
-export type BFragment = Omit<VFragment, "children"> & {
+export type BFragment = {
+  type: typeof NODE_TYPE_FRAGMENT;
+  vnode: VFragment;
   parent?: BNodeParent;
   children: BNode[];
   slot?: HNode;
 };
 
-export function emptyNode(): VNode & BNode {
+export function emptyBNode(): BEmpty {
   return {
     type: NODE_TYPE_EMPTY,
+    parent: undefined,
   };
 }
 
@@ -115,13 +125,24 @@ export const EMPTY_VNODE: VEmpty = {
   type: NODE_TYPE_EMPTY,
 };
 
-export function getNodeKey(node: VNode | BNode): NodeKey | undefined {
+export function getVNodeKey(node: VNode): NodeKey | undefined {
   if (
     node.type === NODE_TYPE_TAG ||
     node.type === NODE_TYPE_CUSTOM ||
     node.type === NODE_TYPE_FRAGMENT
   ) {
     return node.key;
+  }
+  return;
+}
+
+export function getBNodeKey(node: BNode): NodeKey | undefined {
+  if (
+    node.type === NODE_TYPE_TAG ||
+    node.type === NODE_TYPE_CUSTOM ||
+    node.type === NODE_TYPE_FRAGMENT
+  ) {
+    return node.vnode.key;
   }
   return;
 }


### PR DESCRIPTION
Previously it was copying each property by spreading but it looks more natural to just keep direct reference since `VNode` is guaranteed to be immutable.
This would also help potential render skip optimization when `bnode.vnode === vnode` for identical memo render.
- see https://github.com/hi-ogawa/js-utils/pull/163