### PR TITLE
refactor(tiny-react): remove redundant `BNode.parent`

### DIFF
--- a/packages/tiny-react/src/compat/index.ts
+++ b/packages/tiny-react/src/compat/index.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "../hooks";
 import { render } from "../reconciler";
-import { type BNode, EMPTY_VNODE, type FC, type VNode } from "../virtual-dom";
+import { type BNode, EMPTY_NODE, type FC, type VNode } from "../virtual-dom";
 
 // non comprehensive compatibility features
 
@@ -33,7 +33,7 @@ export function createRoot(container: Element) {
       bnode = render(vnode, container, bnode);
     },
     unmount() {
-      render(EMPTY_VNODE, container, bnode);
+      render(EMPTY_NODE, container, bnode);
     },
   };
 }

--- a/packages/tiny-react/src/helper/hyperscript.ts
+++ b/packages/tiny-react/src/helper/hyperscript.ts
@@ -1,5 +1,5 @@
 import {
-  EMPTY_VNODE,
+  EMPTY_NODE,
   NODE_TYPE_CUSTOM,
   NODE_TYPE_FRAGMENT,
   NODE_TYPE_TAG,
@@ -80,7 +80,7 @@ function normalizeComponentChild(child: ComponentChild): VNode {
     typeof child === "undefined" ||
     typeof child === "boolean"
   ) {
-    return EMPTY_VNODE;
+    return EMPTY_NODE;
   }
   if (typeof child === "string" || typeof child === "number") {
     return {

--- a/packages/tiny-react/src/index.test.ts
+++ b/packages/tiny-react/src/index.test.ts
@@ -43,7 +43,6 @@ describe(render, () => {
           "children": [
             {
               "hnode": hello,
-              "parent": [Circular],
               "type": "text",
               "vnode": {
                 "data": "hello",
@@ -53,7 +52,6 @@ describe(render, () => {
             {
               "child": {
                 "hnode": world,
-                "parent": [Circular],
                 "type": "text",
                 "vnode": {
                   "data": "world",
@@ -66,7 +64,6 @@ describe(render, () => {
                 world
               </span>,
               "listeners": Map {},
-              "parent": [Circular],
               "type": "tag",
               "vnode": {
                 "child": {
@@ -124,7 +121,6 @@ describe(render, () => {
           </span>
         </div>,
         "listeners": Map {},
-        "parent": undefined,
         "type": "tag",
         "vnode": {
           "child": {
@@ -174,7 +170,6 @@ describe(render, () => {
       {
         "child": {
           "hnode": reconcile,
-          "parent": [Circular],
           "type": "text",
           "vnode": {
             "data": "reconcile",
@@ -187,7 +182,6 @@ describe(render, () => {
           reconcile
         </div>,
         "listeners": Map {},
-        "parent": undefined,
         "type": "tag",
         "vnode": {
           "child": {
@@ -232,7 +226,6 @@ describe(render, () => {
               {
                 "child": {
                   "hnode": hello,
-                  "parent": [Circular],
                   "type": "text",
                   "vnode": {
                     "data": "hello",
@@ -243,7 +236,6 @@ describe(render, () => {
                   hello
                 </span>,
                 "listeners": Map {},
-                "parent": [Circular],
                 "type": "tag",
                 "vnode": {
                   "child": {
@@ -259,7 +251,6 @@ describe(render, () => {
               },
               {
                 "hnode": world,
-                "parent": [Circular],
                 "type": "text",
                 "vnode": {
                   "data": "world",
@@ -298,7 +289,6 @@ describe(render, () => {
             world
           </div>,
           "listeners": Map {},
-          "parent": [Circular],
           "type": "tag",
           "vnode": {
             "child": {

--- a/packages/tiny-react/src/virtual-dom.ts
+++ b/packages/tiny-react/src/virtual-dom.ts
@@ -70,17 +70,11 @@ export type BNode = BEmpty | BTag | BText | BCustom | BFragment;
 
 export type BNodeParent = BTag | BCustom | BFragment;
 
-export type BEmpty = {
-  type: typeof NODE_TYPE_EMPTY;
-  // not needed since only we need to traverse up only from BCustom?
-  // but for now, make it easier by having uniform `BNode.parent` type
-  parent?: BNodeParent;
-};
+export type BEmpty = VEmpty;
 
 export type BTag = {
   type: typeof NODE_TYPE_TAG;
   vnode: VTag;
-  parent?: BNodeParent;
   child: BNode;
   hnode: HTag;
   listeners: Map<string, () => void>;
@@ -89,7 +83,6 @@ export type BTag = {
 export type BText = {
   type: typeof NODE_TYPE_TEXT;
   vnode: VText;
-  parent?: BNodeParent;
   hnode: HText;
 };
 
@@ -111,17 +104,7 @@ export type BFragment = {
   slot?: HNode;
 };
 
-export function emptyBNode(): BEmpty {
-  return {
-    type: NODE_TYPE_EMPTY,
-    parent: undefined,
-  };
-}
-
-// TODO: identical empty vnode?
-//       for now, this would be critical to not break `memo(Component)` shallow equal with empty children.
-//       ideally, we could VNode to accomodate `null | string | number` primitives...
-export const EMPTY_VNODE: VEmpty = {
+export const EMPTY_NODE: VEmpty = {
   type: NODE_TYPE_EMPTY,
 };
 
@@ -156,4 +139,18 @@ export function getBNodeSlot(node: BNode): HNode | undefined {
     return node.hnode;
   }
   return node.slot;
+}
+
+// bnode parent traversal is only for BCustom and BFragment
+export function getBNodeParent(node: BNode): BNodeParent | undefined {
+  if (node.type === NODE_TYPE_CUSTOM || node.type === NODE_TYPE_FRAGMENT) {
+    return node.parent;
+  }
+  return;
+}
+
+export function setBNodeParent(node: BNode, parent: BNodeParent) {
+  if (node.type === NODE_TYPE_CUSTOM || node.type === NODE_TYPE_FRAGMENT) {
+    node.parent = parent;
+  }
 }


### PR DESCRIPTION
- supersedes https://github.com/hi-ogawa/js-utils/pull/164

This back-pointer is only for BCustom/BFragment's self re-rendering, so it shouldn't be necessary.
This allows `BEmpty` to be constant / identical object (which eventually should be `null` constant cf. https://github.com/hi-ogawa/js-utils/pull/162).