### PR TITLE
refactor(tiny-react): simplify internal typings

### DIFF
--- a/packages/tiny-react/src/compat/index.ts
+++ b/packages/tiny-react/src/compat/index.ts
@@ -79,7 +79,7 @@ export function memo<P extends {}>(
           render: state.render,
           props,
         },
-        onceFc: once(Fc),
+        onceFc: once(Fc) as FC,
       };
     }
     return state.current.vnode;

--- a/packages/tiny-react/src/index.test.ts
+++ b/packages/tiny-react/src/index.test.ts
@@ -302,7 +302,7 @@ describe(render, () => {
             world
           </div>
         </main>,
-        "parent": undefined,
+        "parent": null,
         "slot": <div>
           <span>
             hello

--- a/packages/tiny-react/src/reconciler.ts
+++ b/packages/tiny-react/src/reconciler.ts
@@ -14,9 +14,9 @@ import {
   NODE_TYPE_TAG,
   NODE_TYPE_TEXT,
   type NodeKey,
-  type Props,
   type VCustom,
   type VNode,
+  type VTag,
   getBNodeKey,
   getBNodeParent,
   getBNodeSlot,
@@ -441,7 +441,11 @@ function alignChildrenByKey(
 // https://github.com/preactjs/preact/blob/08b07ccea62bfdb44b983bfe69ae73eb5e4f43c7/compat/src/render.js#L114
 // https://github.com/ryansolid/dom-expressions/blob/a2bd455055f5736bb591abe69a5f5b52568b9ea6/packages/babel-plugin-jsx-dom-expressions/src/dom/element.js#L219-L246
 // https://github.com/ryansolid/dom-expressions/blob/a2bd455055f5736bb591abe69a5f5b52568b9ea6/packages/dom-expressions/src/constants.js#L30-L39
-function reconcileTagProps(bnode: BTag, props: Props, oldProps: Props) {
+function reconcileTagProps(
+  bnode: BTag,
+  props: VTag["props"],
+  oldProps: VTag["props"]
+) {
   for (const k in oldProps) {
     if (!(k in props)) {
       setTagProp(bnode, k, null);
@@ -454,7 +458,7 @@ function reconcileTagProps(bnode: BTag, props: Props, oldProps: Props) {
   }
 }
 
-function hydrateTagProps(bnode: BTag, props: Props) {
+function hydrateTagProps(bnode: BTag, props: VTag["props"]) {
   // TODO: check props mismatch?
   for (const key in props) {
     if (key.startsWith("on")) {

--- a/packages/tiny-react/src/reconciler.ts
+++ b/packages/tiny-react/src/reconciler.ts
@@ -160,8 +160,8 @@ function reconcileNode(
         type: vnode.type,
         vnode,
         children: [],
-        parent: undefined,
-        slot: undefined,
+        parent: null,
+        slot: null,
       } satisfies BFragment;
     }
     // unmount excess bnode.children
@@ -170,7 +170,7 @@ function reconcileNode(
       unmount(bchild);
     }
     // reconcile vnode.children
-    bnode.slot = undefined;
+    bnode.slot = null;
     for (let i = 0; i < vnode.children.length; i++) {
       const bchild = reconcileNode(
         vnode.children[i],
@@ -219,9 +219,9 @@ function reconcileNode(
         vnode,
         child,
         hookContext,
-        hparent: undefined,
-        parent: undefined,
-        slot: undefined,
+        hparent: null,
+        parent: null,
+        slot: null,
       } satisfies BCustom;
     }
     bnode.hparent = hparent;
@@ -274,16 +274,22 @@ function hydrateNode(
     );
     return { type: vnode.type, vnode, hnode } satisfies BText;
   } else if (vnode.type === NODE_TYPE_FRAGMENT) {
-    return { type: vnode.type, vnode, children: [] } satisfies BFragment;
+    return {
+      type: vnode.type,
+      vnode,
+      children: [],
+      parent: null,
+      slot: null,
+    } satisfies BFragment;
   } else if (vnode.type === NODE_TYPE_CUSTOM) {
     return {
       type: vnode.type,
       vnode,
       child: EMPTY_NODE,
       hookContext: new HookContext(updateCustomNodeUnsupported),
-      hparent: undefined,
-      parent: undefined,
-      slot: undefined,
+      hparent: null,
+      parent: null,
+      slot: null,
     } satisfies BCustom;
   }
   return vnode satisfies never;
@@ -389,7 +395,7 @@ function updateParentSlot(child: BNode) {
     }
     if (parent.type === NODE_TYPE_FRAGMENT) {
       // TODO: could optimize something?
-      let slot: HNode | undefined;
+      let slot: HNode | null = null;
       for (const c of parent.children) {
         slot = getBNodeSlot(c) ?? slot;
       }
@@ -530,7 +536,7 @@ function unmountNode(bnode: BNode, skipRemove: boolean) {
   } else if (bnode.type === NODE_TYPE_CUSTOM) {
     bnode.hookContext.cleanupEffect("layout-effect");
     bnode.hookContext.cleanupEffect("effect");
-    bnode.hparent = undefined;
+    bnode.hparent = null;
     unmountNode(bnode.child, skipRemove);
   } else {
     bnode satisfies never;

--- a/packages/tiny-react/src/virtual-dom.ts
+++ b/packages/tiny-react/src/virtual-dom.ts
@@ -94,17 +94,17 @@ export type BCustom = {
   vnode: VCustom;
   child: BNode;
   hookContext: HookContext;
-  parent?: BNodeParent;
-  slot?: HNode;
-  hparent?: HNode; // undefined after unmounted (this flag seems necessary to skip already scheduled re-rendering after unmount)
+  parent: BNodeParent | null;
+  slot: HNode | null;
+  hparent: HNode | null; // null after unmounted so that we can skip already scheduled re-rendering
 };
 
 export type BFragment = {
   type: typeof NODE_TYPE_FRAGMENT;
   vnode: VFragment;
   children: BNode[];
-  parent?: BNodeParent;
-  slot?: HNode;
+  parent: BNodeParent | null;
+  slot: HNode | null;
 };
 
 //
@@ -139,9 +139,9 @@ export function getBNodeKey(node: BNode): NodeKey | undefined {
 }
 
 // "slot" is the last HNode inside the BNode subtree
-export function getBNodeSlot(node: BNode): HNode | undefined {
+export function getBNodeSlot(node: BNode): HNode | null {
   if (node.type === NODE_TYPE_EMPTY) {
-    return;
+    return null;
   }
   if (node.type === NODE_TYPE_TAG || node.type === NODE_TYPE_TEXT) {
     return node.hnode;
@@ -150,11 +150,11 @@ export function getBNodeSlot(node: BNode): HNode | undefined {
 }
 
 // bnode parent traversal is only for BCustom and BFragment
-export function getBNodeParent(node: BNode): BNodeParent | undefined {
+export function getBNodeParent(node: BNode): BNodeParent | null {
   if (node.type === NODE_TYPE_CUSTOM || node.type === NODE_TYPE_FRAGMENT) {
     return node.parent;
   }
-  return;
+  return null;
 }
 
 export function setBNodeParent(node: BNode, parent: BNodeParent) {

--- a/packages/tiny-react/src/virtual-dom.ts
+++ b/packages/tiny-react/src/virtual-dom.ts
@@ -5,7 +5,6 @@ import type { HookContext } from "./hooks";
 //
 
 export type NodeKey = string | number;
-export type Props = Record<string, unknown>;
 export type FC<P = {}> = (props: P) => VNode;
 
 // host node
@@ -36,7 +35,7 @@ export type VTag = {
   type: typeof NODE_TYPE_TAG;
   key?: NodeKey;
   name: string; // tagName
-  props: Props & {
+  props: Record<string, unknown> & {
     ref?: (el: HTag | null) => VNode;
     children?: ComponentChildren;
   };

--- a/packages/tiny-react/src/virtual-dom.ts
+++ b/packages/tiny-react/src/virtual-dom.ts
@@ -6,7 +6,7 @@ import type { HookContext } from "./hooks";
 
 export type NodeKey = string | number;
 export type Props = Record<string, unknown>;
-export type FC<P = any> = (props: P) => VNode;
+export type FC<P = {}> = (props: P) => VNode;
 
 // host node
 export type HNode = Node;
@@ -56,8 +56,8 @@ export type VText = {
 export type VCustom = {
   type: typeof NODE_TYPE_CUSTOM;
   key?: NodeKey;
-  props: Props;
-  render: (props: Props) => VNode;
+  props: {};
+  render: (props: {}) => VNode;
 };
 
 export type VFragment = {
@@ -93,18 +93,18 @@ export type BText = {
 export type BCustom = {
   type: typeof NODE_TYPE_CUSTOM;
   vnode: VCustom;
-  parent?: BNodeParent;
   child: BNode;
+  hookContext: HookContext;
+  parent?: BNodeParent;
   slot?: HNode;
   hparent?: HNode; // undefined after unmounted (this flag seems necessary to skip already scheduled re-rendering after unmount)
-  hookContext: HookContext;
 };
 
 export type BFragment = {
   type: typeof NODE_TYPE_FRAGMENT;
   vnode: VFragment;
-  parent?: BNodeParent;
   children: BNode[];
+  parent?: BNodeParent;
   slot?: HNode;
 };
 
@@ -168,7 +168,7 @@ export function setBNodeParent(node: BNode, parent: BNodeParent) {
 // jsx-runtime compatible VNode factory
 //
 
-export type ComponentType = string | FC;
+export type ComponentType = string | FC<any>;
 
 export type ComponentChild =
   | VNode


### PR DESCRIPTION
For "optional" property, let's use `null` instead of `undefined` for `BNode` since that gives more explicitness and prevents some forgotten initialized property.