### PR TITLE
fix(tiny-refresh): fix HMR when component re-mount

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@hiogawa/utils": "workspace:*",
     "@hiogawa/utils-node": "workspace:*",
     "@playwright/test": "^1.39.0",
+    "@swc/core": "^1.3.95",
     "@tsconfig/strictest": "^2.0.1",
     "@types/node": "^20.8.6",
     "esbuild": "^0.18.10",

--- a/packages/tiny-react/src/hmr/index.test.ts
+++ b/packages/tiny-react/src/hmr/index.test.ts
@@ -6,7 +6,7 @@ import {
   setupHmrVite,
 } from ".";
 import { h } from "../helper/hyperscript";
-import { useEffect, useState } from "../hooks";
+import { useEffect, useReducer } from "../hooks";
 import { render } from "../reconciler";
 import { sleepFrame } from "../test-utils";
 import { createElement } from "../virtual-dom";
@@ -37,7 +37,7 @@ describe(setupHmrVite, () => {
     {
       const registry = createHmrRegistry({
         createElement,
-        useState,
+        useReducer,
         useEffect,
       });
 
@@ -86,7 +86,7 @@ describe(setupHmrVite, () => {
     {
       const registry = createHmrRegistry({
         createElement,
-        useState,
+        useReducer,
         useEffect,
       });
 
@@ -131,7 +131,7 @@ describe(setupHmrVite, () => {
     {
       const registry = createHmrRegistry({
         createElement,
-        useState,
+        useReducer,
         useEffect,
       });
 

--- a/packages/tiny-refresh/examples/react/README.md
+++ b/packages/tiny-refresh/examples/react/README.md
@@ -6,4 +6,9 @@ demo app for integration test
 pnpm i
 pnpm dev
 pnpm test-e2e
+
+# use @hiogawa/tiny-react
+# TODO: e2e seems flaky?
+REACT_COMPAT=@hiogawa/tiny-react pnpm dev
+REACT_COMPAT=@hiogawa/tiny-react pnpm test-e2e
 ```

--- a/packages/tiny-refresh/examples/react/README.md
+++ b/packages/tiny-refresh/examples/react/README.md
@@ -1,5 +1,7 @@
 # tiny-refresh/examples/react
 
+demo app for integration test
+
 ```sh
 pnpm i
 pnpm dev

--- a/packages/tiny-refresh/examples/react/e2e/hmr.test.ts
+++ b/packages/tiny-refresh/examples/react/e2e/hmr.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
-import { test } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 
-test("hmr", async ({ page }) => {
+test("hmr basic", async ({ page }) => {
   await page.goto("/");
 
   async function increment() {
@@ -79,6 +79,39 @@ test("hmr", async ({ page }) => {
           );
         }
       );
+    }
+  );
+});
+
+test("hmr show/hide", async ({ page }) => {
+  await page.goto("/");
+
+  async function increment() {
+    await page.getByRole("button", { name: "+1" }).first().click();
+  }
+
+  async function checkInner(value: number, add: number) {
+    const text = `Inner: counter + ${add} = ${value + add}`;
+    await page.locator("#inner1").getByText(text).click();
+    await page.locator("#inner2").getByText(text).click();
+  }
+
+  await expect(page.locator("#inner4-message")).toHaveText("hello");
+  await increment();
+  await expect(page.locator("#inner4-message")).toHaveText("");
+  await increment();
+  await expect(page.locator("#inner4-message")).toHaveText("hello");
+
+  // update message
+  await withEditFile(
+    "src/other-file.tsx",
+    (code) => code.replace(`const message = "hello"`, `const message = "hey"`),
+    async () => {
+      await expect(page.locator("#inner4-message")).toHaveText("hey");
+      await increment();
+      await expect(page.locator("#inner4-message")).toHaveText("");
+      await increment();
+      await expect(page.locator("#inner4-message")).toHaveText("hey");
     }
   );
 });

--- a/packages/tiny-refresh/examples/react/package.json
+++ b/packages/tiny-refresh/examples/react/package.json
@@ -8,6 +8,7 @@
   },
   "devDependencies": {
     "@hiogawa/theme-script": "workspace:*",
+    "@hiogawa/tiny-react": "workspace:*",
     "@hiogawa/tiny-refresh": "workspace:*",
     "@hiogawa/unocss-preset-antd": "2.2.1-pre.3",
     "@hiogawa/utils": "workspace:*",

--- a/packages/tiny-refresh/examples/react/src/app.tsx
+++ b/packages/tiny-refresh/examples/react/src/app.tsx
@@ -46,7 +46,8 @@ export function Outer() {
       <div className="border-t"></div>
       <div id="inner4">
         <div className="flex gap-1">
-          show if "outer % 2 = 0" : {state % 2 === 0 && <InnerShowHide />}
+          show if "outer % 2 = 0" :{" "}
+          <div id="inner4-message">{state % 2 === 0 && <InnerShowHide />}</div>
         </div>
       </div>
     </div>

--- a/packages/tiny-refresh/examples/react/src/app.tsx
+++ b/packages/tiny-refresh/examples/react/src/app.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { InnerOther } from "./other-file";
+import { InnerOther, InnerShowHide } from "./other-file";
 
 export function Root() {
   return (
@@ -42,6 +42,12 @@ export function Outer() {
       <div className="border-t"></div>
       <div id="inner3">
         <InnerOther value={state} />
+      </div>
+      <div className="border-t"></div>
+      <div id="inner4">
+        <div className="flex gap-1">
+          show if "outer % 2 = 0" : {state % 2 === 0 && <InnerShowHide />}
+        </div>
       </div>
     </div>
   );

--- a/packages/tiny-refresh/examples/react/src/other-file.tsx
+++ b/packages/tiny-refresh/examples/react/src/other-file.tsx
@@ -26,3 +26,9 @@ export function InnerOther(props: { value: number }) {
     </div>
   );
 }
+
+export function InnerShowHide() {
+  const message = "hey";
+  console.log("[render] InnerShowHide", message);
+  return <div>{message}</div>;
+}

--- a/packages/tiny-refresh/examples/react/src/other-file.tsx
+++ b/packages/tiny-refresh/examples/react/src/other-file.tsx
@@ -28,7 +28,6 @@ export function InnerOther(props: { value: number }) {
 }
 
 export function InnerShowHide() {
-  const message = "hey";
-  console.log("[render] InnerShowHide", message);
+  const message = "hello";
   return <div>{message}</div>;
 }

--- a/packages/tiny-refresh/examples/react/vite.config.ts
+++ b/packages/tiny-refresh/examples/react/vite.config.ts
@@ -1,14 +1,28 @@
+import process from "node:process";
 import { vitePluginTinyRefresh } from "@hiogawa/tiny-refresh/dist/vite";
 import unocss from "unocss/vite";
 import { defineConfig } from "vite";
+
+// allow override runtime to test both react and tiny-react with the same code
+//   REACT_COMPAT=@hiogawa/tiny-react pnpm -C packages/tiny-refresh/examples/react dev
+const reactCompat = process.env["REACT_COMPAT"];
 
 export default defineConfig({
   plugins: [unocss(), vitePluginTinyRefresh()],
   clearScreen: false,
   esbuild: {
+    jsxImportSource: reactCompat,
     // `jsxDev` mode injects `lineNumber` etc...
     // which might affect tiny-refresh's `Function.toString` check and cause redundant refresh.
     // Depending on the use case, disabling jsxDev entirely might be reasonable.
     // jsxDev: false,
+  },
+  resolve: {
+    alias: reactCompat
+      ? {
+          react: reactCompat,
+          "react-dom/client": reactCompat,
+        }
+      : undefined,
   },
 });

--- a/packages/tiny-refresh/examples/react/vite.config.ts
+++ b/packages/tiny-refresh/examples/react/vite.config.ts
@@ -5,4 +5,10 @@ import { defineConfig } from "vite";
 export default defineConfig({
   plugins: [unocss(), vitePluginTinyRefresh()],
   clearScreen: false,
+  esbuild: {
+    // `jsxDev` mode injects `lineNumber` etc...
+    // which might affect tiny-refresh's `Function.toString` check and cause redundant refresh.
+    // Depending on the use case, disabling jsxDev entirely might be reasonable.
+    // jsxDev: false,
+  },
 });

--- a/packages/tiny-refresh/package.json
+++ b/packages/tiny-refresh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/tiny-refresh",
-  "version": "0.0.1-pre.9",
+  "version": "0.0.1-pre.10",
   "homepage": "https://github.com/hi-ogawa/js-utils/tree/main/packages/tiny-refresh",
   "repository": {
     "type": "git",

--- a/packages/tiny-refresh/package.json
+++ b/packages/tiny-refresh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/tiny-refresh",
-  "version": "0.0.1-pre.10",
+  "version": "0.0.1-pre.11",
   "homepage": "https://github.com/hi-ogawa/js-utils/tree/main/packages/tiny-refresh",
   "repository": {
     "type": "git",

--- a/packages/tiny-refresh/src/runtime.ts
+++ b/packages/tiny-refresh/src/runtime.ts
@@ -84,10 +84,8 @@ export function createHmrComponent(
       }
       // expose "force update" to registry
       const forceUpdate = () => setState((prev) => !prev);
-      // current.listeners.add(forceUpdate);
       current.listeners.add(forceUpdate);
       return () => {
-        // current.listeners.delete(forceUpdate);
         current.listeners.delete(forceUpdate);
       };
     }, []);
@@ -117,19 +115,19 @@ export function createHmrComponent(
     return current.options.remount
       ? createElement(current.component, props)
       : createElement(UnsafeWrapperFc, {
-          component: current.component,
+          current,
           props,
         });
   };
 
   const UnsafeWrapperFc: ReactTypes.FC = ({
-    component,
+    current,
     props,
   }: {
-    component: ReactTypes.FC;
+    current: HmrComponentData;
     props: any;
   }) => {
-    return component(props);
+    return current.component(props);
   };
 
   // patch Function.name for react error stacktrace

--- a/packages/tiny-refresh/src/runtime.ts
+++ b/packages/tiny-refresh/src/runtime.ts
@@ -36,7 +36,7 @@ interface HmrRegistry {
   };
   componentMap: Map<string, HmrComponentData>;
   debug?: boolean; // to hide log for testing
-  // each HmrRegistry references initial registry (except initial itself)
+  // each HmrRegistry references initial registry (except initial module itself)
   // since all following changes are reflected to the initial registry.
   initial?: HmrRegistry;
 }
@@ -210,7 +210,7 @@ export function setupHmrWebpack(hot: WebpackHot, registry: HmrRegistry) {
   // perspective flips for webpack since `hot.data` is passed by old module.
   const lastRegistry = hot.data && hot.data[REGISTRY_KEY];
   if (lastRegistry) {
-    const patchSuccess = lastRegistry && patchRegistry(lastRegistry, registry);
+    const patchSuccess = patchRegistry(lastRegistry, registry);
     if (!patchSuccess) {
       hot.invalidate();
     }

--- a/packages/tiny-refresh/src/runtime.ts
+++ b/packages/tiny-refresh/src/runtime.ts
@@ -83,7 +83,7 @@ export function createHmrComponent(
       const forceUpdate = () => setState((prev) => !prev);
       current.listeners.add(forceUpdate);
       return () => {
-        current.listeners.add(forceUpdate);
+        current.listeners.delete(forceUpdate);
       };
     }, []);
 

--- a/packages/tiny-refresh/src/runtime.ts
+++ b/packages/tiny-refresh/src/runtime.ts
@@ -75,30 +75,21 @@ export function createHmrComponent(
   const { createElement, useEffect, useState } = registry.runtime;
 
   const WrapperFc: ReactTypes.FC = (props) => {
-    // const [latest, setLatest] = useState(() => current);
-
-    // TODO: useReducer
     const [_state, setState] = useState(true);
 
     useEffect(() => {
       // expose "force update" to registry
       const forceUpdate = () => setState((prev) => !prev);
-      // current.listeners.add(setLatest);
       current.listeners.add(forceUpdate);
       return () => {
         current.listeners.add(forceUpdate);
-        // current.listeners.delete(setLatest);
       };
     }, []);
 
-    const latest2 = registry.componentMap.get(name);
-    if (!latest2) {
+    const latest = registry.componentMap.get(name);
+    if (!latest) {
       return `!!! [tiny-refresh] missing '${name}' !!!`;
     }
-
-    return latest2.options.remount
-      ? createElement(latest2.component, props)
-      : createElement(UnsafeWrapperFc, { component: latest2.component, props });
 
     //
     // approach 1.
@@ -118,9 +109,9 @@ export function createHmrComponent(
     //   For now, however, we allow this mode via explicit "// @hmr-unsafe" comment.
     //
 
-    // return latest.options.remount
-    //   ? createElement(latest.component, props)
-    //   : createElement(UnsafeWrapperFc, { latest, props });
+    return latest.options.remount
+      ? createElement(latest.component, props)
+      : createElement(UnsafeWrapperFc, { component: latest.component, props });
   };
 
   const UnsafeWrapperFc: ReactTypes.FC = ({

--- a/packages/tiny-refresh/src/runtime.ts
+++ b/packages/tiny-refresh/src/runtime.ts
@@ -65,6 +65,7 @@ export function createHmrComponent(
   Fc: ReactTypes.FC,
   options: HmrComponentOptions
 ) {
+  // `patchRegistry` will mutate this `current` to synchronize latest data
   const current: HmrComponentData = {
     component: Fc,
     listeners: new Set(),
@@ -86,11 +87,6 @@ export function createHmrComponent(
       };
     }, []);
 
-    const latest = registry.componentMap.get(name);
-    if (!latest) {
-      return `!!! [tiny-refresh] missing '${name}' !!!`;
-    }
-
     //
     // approach 1.
     //
@@ -109,9 +105,9 @@ export function createHmrComponent(
     //   For now, however, we allow this mode via explicit "// @hmr-unsafe" comment.
     //
 
-    return latest.options.remount
-      ? createElement(latest.component, props)
-      : createElement(UnsafeWrapperFc, { component: latest.component, props });
+    return current.options.remount
+      ? createElement(current.component, props)
+      : createElement(UnsafeWrapperFc, { component: current.component, props });
   };
 
   const UnsafeWrapperFc: ReactTypes.FC = ({
@@ -168,7 +164,7 @@ function patchRegistry(currentReg: HmrRegistry, latestReg: HmrRegistry) {
     if (latestReg.debug) {
       // cf. "[vite] hot updated" log https://github.com/vitejs/vite/pull/8855
       console.debug(
-        `[tiny-refresh] refresh '${key}' (remount = ${latest.options.remount}, listeners.size = ${latest.listeners.size})`
+        `[tiny-refresh] refresh '${key}' (remount = ${current.options.remount}, listeners.size = ${current.listeners.size})`
       );
     }
     for (const setState of current.listeners) {

--- a/packages/tiny-refresh/src/runtime.ts
+++ b/packages/tiny-refresh/src/runtime.ts
@@ -76,6 +76,8 @@ export function createHmrComponent(
   const WrapperFc: ReactTypes.FC = (props) => {
     const current = registry.componentMap.get(name);
 
+    // TODO: replace with
+    //   const forceUpdate = useReducer(prev => !prev, true)[1];
     const [_state, setState] = useState(true);
 
     useEffect(() => {

--- a/packages/tiny-refresh/src/transform.test.ts
+++ b/packages/tiny-refresh/src/transform.test.ts
@@ -35,7 +35,7 @@ function CompNooo() {
       import * as $$refresh from \\"@hiogawa/tiny-refresh\\";
       const $$registry = $$refresh.createHmrRegistry({
         createElement: $$runtime.createElement,
-        useState: $$runtime.useState,
+        useReducer: $$runtime.useReducer,
         useEffect: $$runtime.useEffect,
       }, false);
 
@@ -126,7 +126,7 @@ const UPPER = 1;
       import * as $$refresh from \\"@hiogawa/tiny-refresh\\";
       const $$registry = $$refresh.createHmrRegistry({
         createElement: $$runtime.createElement,
-        useState: $$runtime.useState,
+        useReducer: $$runtime.useReducer,
         useEffect: $$runtime.useEffect,
       }, false);
 

--- a/packages/tiny-refresh/src/transform.ts
+++ b/packages/tiny-refresh/src/transform.ts
@@ -119,7 +119,7 @@ import * as $$runtime from "${runtime}";
 import * as $$refresh from "${refresh}";
 const $$registry = $$refresh.createHmrRegistry({
   createElement: $$runtime.createElement,
-  useState: $$runtime.useState,
+  useReducer: $$runtime.useReducer,
   useEffect: $$runtime.useEffect,
 }, ${debug});
 `;

--- a/packages/tiny-refresh/tsup.config.ts
+++ b/packages/tiny-refresh/tsup.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "tsup";
 export default defineConfig({
   entry: ["src/index.ts", "src/vite.ts", "src/webpack.ts"],
   format: ["esm", "cjs"],
-  // can be used for old webpack 4
+  // support old webpack 4
   target: "es5",
   dts: true,
   splitting: false,

--- a/packages/tiny-refresh/tsup.config.ts
+++ b/packages/tiny-refresh/tsup.config.ts
@@ -3,6 +3,8 @@ import { defineConfig } from "tsup";
 export default defineConfig({
   entry: ["src/index.ts", "src/vite.ts", "src/webpack.ts"],
   format: ["esm", "cjs"],
+  // can be used for old webpack 4
+  target: "es5",
   dts: true,
   splitting: false,
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -309,6 +309,9 @@ importers:
       '@hiogawa/theme-script':
         specifier: workspace:*
         version: link:../../../theme-script
+      '@hiogawa/tiny-react':
+        specifier: workspace:*
+        version: link:../../../tiny-react
       '@hiogawa/tiny-refresh':
         specifier: workspace:*
         version: link:../..

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       '@playwright/test':
         specifier: ^1.39.0
         version: 1.39.0
+      '@swc/core':
+        specifier: ^1.3.95
+        version: 1.3.95
       '@tsconfig/strictest':
         specifier: ^2.0.1
         version: 2.0.1
@@ -46,7 +49,7 @@ importers:
         version: 2.8.8
       tsup:
         specifier: ^7.1.0
-        version: 7.1.0(typescript@5.1.6)
+        version: 7.1.0(@swc/core@1.3.95)(typescript@5.1.6)
       tsx:
         specifier: ^3.12.7
         version: 3.12.7
@@ -1720,6 +1723,129 @@ packages:
       '@types/estree': 1.0.2
       estree-walker: 2.0.2
       picomatch: 2.3.1
+    dev: true
+
+  /@swc/core-darwin-arm64@1.3.95:
+    resolution: {integrity: sha512-VAuBAP3MNetO/yBIBzvorUXq7lUBwhfpJxYViSxyluMwtoQDhE/XWN598TWMwMl1ZuImb56d7eUsuFdjgY7pJw==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-darwin-x64@1.3.95:
+    resolution: {integrity: sha512-20vF2rvUsN98zGLZc+dsEdHvLoCuiYq/1B+TDeE4oolgTFDmI1jKO+m44PzWjYtKGU9QR95sZ6r/uec0QC5O4Q==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-linux-arm-gnueabihf@1.3.95:
+    resolution: {integrity: sha512-oEudEM8PST1MRNGs+zu0cx5i9uP8TsLE4/L9HHrS07Ck0RJ3DCj3O2fU832nmLe2QxnAGPwBpSO9FntLfOiWEQ==}
+    engines: {node: '>=10'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-linux-arm64-gnu@1.3.95:
+    resolution: {integrity: sha512-pIhFI+cuC1aYg+0NAPxwT/VRb32f2ia8oGxUjQR6aJg65gLkUYQzdwuUmpMtFR2WVf7WVFYxUnjo4UyMuyh3ng==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-linux-arm64-musl@1.3.95:
+    resolution: {integrity: sha512-ZpbTr+QZDT4OPJfjPAmScqdKKaT+wGurvMU5AhxLaf85DuL8HwUwwlL0n1oLieLc47DwIJEMuKQkYhXMqmJHlg==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-linux-x64-gnu@1.3.95:
+    resolution: {integrity: sha512-n9SuHEFtdfSJ+sHdNXNRuIOVprB8nbsz+08apKfdo4lEKq6IIPBBAk5kVhPhkjmg2dFVHVo4Tr/OHXM1tzWCCw==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-linux-x64-musl@1.3.95:
+    resolution: {integrity: sha512-L1JrVlsXU3LC0WwmVnMK9HrOT2uhHahAoPNMJnZQpc18a0paO9fqifPG8M/HjNRffMUXR199G/phJsf326UvVg==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-win32-arm64-msvc@1.3.95:
+    resolution: {integrity: sha512-YaP4x/aZbUyNdqCBpC2zL8b8n58MEpOUpmOIZK6G1SxGi+2ENht7gs7+iXpWPc0sy7X3YPKmSWMAuui0h8lgAA==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-win32-ia32-msvc@1.3.95:
+    resolution: {integrity: sha512-w0u3HI916zT4BC/57gOd+AwAEjXeUlQbGJ9H4p/gzs1zkSHtoDQghVUNy3n/ZKp9KFod/95cA8mbVF9t1+6epQ==}
+    engines: {node: '>=10'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-win32-x64-msvc@1.3.95:
+    resolution: {integrity: sha512-5RGnMt0S6gg4Gc6QtPUJ3Qs9Un4sKqccEzgH/tj7V/DVTJwKdnBKxFZfgQ34OR2Zpz7zGOn889xwsFVXspVWNA==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core@1.3.95:
+    resolution: {integrity: sha512-PMrNeuqIusq9DPDooV3FfNEbZuTu5jKAc04N3Hm6Uk2Fl49cqElLFQ4xvl4qDmVDz97n3n/C1RE0/f6WyGPEiA==}
+    engines: {node: '>=10'}
+    requiresBuild: true
+    peerDependencies:
+      '@swc/helpers': ^0.5.0
+    peerDependenciesMeta:
+      '@swc/helpers':
+        optional: true
+    dependencies:
+      '@swc/counter': 0.1.2
+      '@swc/types': 0.1.5
+    optionalDependencies:
+      '@swc/core-darwin-arm64': 1.3.95
+      '@swc/core-darwin-x64': 1.3.95
+      '@swc/core-linux-arm-gnueabihf': 1.3.95
+      '@swc/core-linux-arm64-gnu': 1.3.95
+      '@swc/core-linux-arm64-musl': 1.3.95
+      '@swc/core-linux-x64-gnu': 1.3.95
+      '@swc/core-linux-x64-musl': 1.3.95
+      '@swc/core-win32-arm64-msvc': 1.3.95
+      '@swc/core-win32-ia32-msvc': 1.3.95
+      '@swc/core-win32-x64-msvc': 1.3.95
+    dev: true
+
+  /@swc/counter@0.1.2:
+    resolution: {integrity: sha512-9F4ys4C74eSTEUNndnER3VJ15oru2NumfQxS8geE+f3eB5xvfxpWyqE5XlVnxb/R14uoXi6SLbBwwiDSkv+XEw==}
+    dev: true
+
+  /@swc/types@0.1.5:
+    resolution: {integrity: sha512-myfUej5naTBWnqOCc/MdVOLVjXUXtIA+NpDrDBKJtLLg2shUjBu3cZmB/85RyitKc55+lUUyl7oRfLOvkr2hsw==}
     dev: true
 
   /@tanstack/query-core@4.29.19:
@@ -5360,7 +5486,7 @@ packages:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
     dev: true
 
-  /tsup@7.1.0(typescript@5.1.6):
+  /tsup@7.1.0(@swc/core@1.3.95)(typescript@5.1.6):
     resolution: {integrity: sha512-mazl/GRAk70j8S43/AbSYXGgvRP54oQeX8Un4iZxzATHt0roW0t6HYDVZIXMw0ZQIpvr1nFMniIVnN5186lW7w==}
     engines: {node: '>=16.14'}
     hasBin: true
@@ -5376,6 +5502,7 @@ packages:
       typescript:
         optional: true
     dependencies:
+      '@swc/core': 1.3.95
       bundle-require: 4.0.1(esbuild@0.18.10)
       cac: 6.7.14
       chokidar: 3.5.3


### PR DESCRIPTION
For starter, added reproduction. No idea why parent gets stale child when toggling "show".
I was seeing this bug when react-router switches back routes in the demo app https://github.com/hi-ogawa/unocss-preset-antd/tree/main/packages/app

## todo

- [ ] ~debug to show which "version" is rendering?~
- [x] test tiny-react
- [x] test webpack
- [x] refactor

---

Found the issue and it's obvious that the `WrapperFC` will render old one since it'll get updated only during it's mounted:

https://github.com/hi-ogawa/js-utils/blob/fc85ac846f62c473d1d5f4567bcaffacb9f1a08c/packages/tiny-refresh/src/runtime.ts#L77-L86


Need to find a way to get the "latest" one for `useState(() => <latest>)` on re-mount.

---

I don't think `useState` is actually necessarily to pass "ground truth" state.
Instead, the new approach is that to synchronize latest state into "initial" module and then each "non-initial" module can reference that.