### PR TITLE
refactor(utils): simplify `regExpRaw`

### DIFF
--- a/.changeset/shy-brooms-live.md
+++ b/.changeset/shy-brooms-live.md
@@ -1,0 +1,5 @@
+---
+"@hiogawa/utils": patch
+---
+
+refactor: refactor regExpRaw

--- a/packages/utils/src/index.test.ts
+++ b/packages/utils/src/index.test.ts
@@ -583,6 +583,22 @@ describe(regExpRaw, () => {
     `);
     expect("/username/he y/profile".match(re)).toMatchInlineSnapshot("null");
   });
+
+  it("string", () => {
+    const re = regExpRaw`/username/${"\\w+"}/profile`;
+    expect(re).toMatchInlineSnapshot(
+      "/\\\\/username\\\\/\\\\w\\+\\\\/profile/"
+    );
+    expect(re.source).toMatchInlineSnapshot(
+      '"\\\\/username\\\\/\\\\w+\\\\/profile"'
+    );
+    expect("/username/hey/profile".match(re)).toMatchInlineSnapshot(`
+      [
+        "/username/hey/profile",
+      ]
+    `);
+    expect("/username/he y/profile".match(re)).toMatchInlineSnapshot("null");
+  });
 });
 
 describe(escapeRegExp, () => {

--- a/packages/utils/src/regexp.ts
+++ b/packages/utils/src/regexp.ts
@@ -1,26 +1,19 @@
-import { zip } from "./lodash";
 import { tinyassert } from "./tinyassert";
 
 /**
- * new RegExp(String.raw`...`) with inner strings are escaped which allows easier composition for matching urls e.g.
+ * Simple combination of `String.raw` and `RegExp`
  * @example
  * regExpRaw`/username/${/\w+/}/profile`
  */
 export function regExpRaw(
-  { raw }: TemplateStringsArray,
-  ...params: RegExp[]
+  strings: TemplateStringsArray,
+  ...params: (string | RegExp)[]
 ): RegExp {
-  tinyassert(raw.length === params.length + 1);
   return new RegExp(
-    [
-      ...zip(
-        raw,
-        params.map((p) => p.source)
-      ),
-      raw.slice(-1),
-    ]
-      .flat()
-      .join("")
+    String.raw(
+      strings,
+      ...params.map((p) => (typeof p === "string" ? p : p.source))
+    )
   );
 }
 

--- a/packages/utils/src/regexp.ts
+++ b/packages/utils/src/regexp.ts
@@ -1,7 +1,7 @@
 import { tinyassert } from "./tinyassert";
 
 /**
- * Simple combination of `String.raw` and `RegExp`
+ * Composition of `String.raw` and `RegExp`
  * @example
  * regExpRaw`/username/${/\w+/}/profile`
  */


### PR DESCRIPTION
I realized `RegExp` and `String.raw` can be composed like this directly.