### PR TITLE
feat(utils): replace `newPromiseWithResolvers` with `createManualPromise`

### DIFF
--- a/.changeset/hip-crabs-pump.md
+++ b/.changeset/hip-crabs-pump.md
@@ -1,0 +1,5 @@
+---
+"@hiogawa/utils": minor
+---
+
+feat: add `createManualPromise` and deprecate `newPromiseWithResolvers`

--- a/packages/tiny-rpc/src/adapter-message-port.ts
+++ b/packages/tiny-rpc/src/adapter-message-port.ts
@@ -1,6 +1,6 @@
 import {
   type Result,
-  newPromiseWithResolvers,
+  createManualPromise,
   wrapErrorAsync,
 } from "@hiogawa/utils";
 import {
@@ -72,16 +72,16 @@ export function messagePortClientAdapter({
         id: generateId(),
         data,
       };
-      const promiseResolvers = newPromiseWithResolvers<ResponsePayload>();
+      const responsePromise = createManualPromise<ResponsePayload>();
       const unlisten = listen(port, (ev) => {
         const res = ev.data as ResponsePayload;
         if (res.id === req.id) {
-          promiseResolvers.resolve(res);
+          responsePromise.resolve(res);
           unlisten();
         }
       });
       port.postMessage(req);
-      const res = await promiseResolvers.promise;
+      const res = await responsePromise;
       if (!res.result.ok) {
         throw TinyRpcError.deserialize(res.result.value);
       }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/utils",
-  "version": "1.6.1-pre.9",
+  "version": "1.6.1-pre.10",
   "homepage": "https://github.com/hi-ogawa/js-utils/tree/main/packages/utils",
   "repository": {
     "type": "git",

--- a/packages/utils/src/index.test.ts
+++ b/packages/utils/src/index.test.ts
@@ -11,7 +11,7 @@ import {
   typedBoolean,
 } from "./misc";
 import { mapOption, none } from "./option";
-import { newPromiseWithResolvers } from "./promise";
+import { createManualPromise } from "./promise";
 import { escapeRegExp, mapRegExp, regExpRaw } from "./regexp";
 import {
   Err,
@@ -509,10 +509,10 @@ describe(none, () => {
   });
 });
 
-describe(newPromiseWithResolvers, () => {
+describe(createManualPromise, () => {
   it("resolve", async () => {
-    const { promise, resolve } = newPromiseWithResolvers<number>();
-    resolve(123);
+    const promise = createManualPromise<number>();
+    promise.resolve(123);
     const result = await wrapErrorAsync(() => promise);
     expect(result).toMatchInlineSnapshot(`
       {
@@ -523,8 +523,8 @@ describe(newPromiseWithResolvers, () => {
   });
 
   it("reject", async () => {
-    const { promise, reject } = newPromiseWithResolvers<number>();
-    reject(123);
+    const promise = createManualPromise<number>();
+    promise.reject(123);
     const result = await wrapErrorAsync(() => promise);
     expect(result).toMatchInlineSnapshot(`
       {

--- a/packages/utils/src/promise.ts
+++ b/packages/utils/src/promise.ts
@@ -1,4 +1,24 @@
-// TODO: how is it different from this? https://github.com/remix-run/remix/blob/1d3d86eaceb7784c56d34d963310ecbcb8c9637a/packages/remix-dev/channel.ts#L1-L2
+// inspired by
+//   ManualPromise https://github.com/microsoft/playwright/blob/10dda30c7f417a92f782e21368fbb211a679838a/packages/playwright-core/src/utils/manualPromise.ts#L31-L38
+//   createDefer https://github.com/vitest-dev/vitest/blob/9c552b6f8decb78677b20e870eb430184e0b78ea/packages/utils/src/helpers.ts#L155
+//   channel https://github.com/remix-run/remix/blob/9a845b6576fbaf112161f6f97295f6dbb44d913f/packages/remix-dev/channel.ts#L1-L2
+interface ManualPromise<T> extends PromiseLike<T> {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (value: unknown) => void;
+}
+
+export function createManualPromise<T>(): ManualPromise<T> {
+  let resolve!: ManualPromise<T>["resolve"];
+  let reject!: ManualPromise<T>["reject"];
+  const promise = new Promise<T>((resolve_, reject_) => {
+    resolve = resolve_;
+    reject = reject_;
+  });
+  return { promise, resolve, reject, then: promise.then.bind(promise) };
+}
+
+/** @deprecated use createManualPromise instead */
 export function newPromiseWithResolvers<T>() {
   let resolve!: (value: T | PromiseLike<T>) => void;
   let reject!: (value: unknown) => void;

--- a/packages/utils/src/result.ts
+++ b/packages/utils/src/result.ts
@@ -19,7 +19,7 @@ export function wrapError<T>(getValue: () => T): Result<T, unknown> {
 }
 
 export async function wrapErrorAsync<T>(
-  getValue: () => Promise<T>
+  getValue: () => PromiseLike<T>
 ): Promise<Result<T, unknown>> {
   try {
     return Ok(await getValue());
@@ -36,7 +36,7 @@ export function okToOption<T>(result: Result<T, unknown>): T | undefined {
  * @deprecated use `wrapErrorAsync` instead
  */
 export async function wrapPromise<T>(
-  value: Promise<T>
+  value: PromiseLike<T>
 ): Promise<Result<T, unknown>> {
   try {
     return Ok(await value);


### PR DESCRIPTION
I just liked the sound of "manual promise". I didn't go too far to do `class ManualPromise extends Promise` like playwright since `PromiseLike` interfaces seems convenient enough.