### PR TITLE
fix(tiny-refresh): skip transform on ssr

### DIFF
--- a/.changeset/gold-moles-glow.md
+++ b/.changeset/gold-moles-glow.md
@@ -1,0 +1,5 @@
+---
+"@hiogawa/tiny-refresh": patch
+---
+
+Vite 5 compat for ssr check

--- a/packages/tiny-react/package.json
+++ b/packages/tiny-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/tiny-react",
-  "version": "0.0.2-pre.3",
+  "version": "0.0.2-pre.4",
   "homepage": "https://github.com/hi-ogawa/js-utils/tree/main/packages/tiny-react",
   "repository": {
     "type": "git",

--- a/packages/tiny-react/package.json
+++ b/packages/tiny-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/tiny-react",
-  "version": "0.0.2-pre.4",
+  "version": "0.0.2-pre.5",
   "homepage": "https://github.com/hi-ogawa/js-utils/tree/main/packages/tiny-react",
   "repository": {
     "type": "git",

--- a/packages/tiny-refresh/package.json
+++ b/packages/tiny-refresh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/tiny-refresh",
-  "version": "0.0.1-pre.12",
+  "version": "0.0.1-pre.13",
   "homepage": "https://github.com/hi-ogawa/js-utils/tree/main/packages/tiny-refresh",
   "repository": {
     "type": "git",

--- a/packages/tiny-refresh/package.json
+++ b/packages/tiny-refresh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/tiny-refresh",
-  "version": "0.0.1-pre.11",
+  "version": "0.0.1-pre.12",
   "homepage": "https://github.com/hi-ogawa/js-utils/tree/main/packages/tiny-refresh",
   "repository": {
     "type": "git",

--- a/packages/tiny-refresh/src/vite.ts
+++ b/packages/tiny-refresh/src/vite.ts
@@ -22,8 +22,8 @@ export function vitePluginTinyRefresh(options?: {
     apply(config, env) {
       return env.command === "serve" && !config.build?.ssr;
     },
-    transform(code, id, _options) {
-      if (filter(id)) {
+    transform(code, id, transformOptions) {
+      if (!transformOptions?.ssr && filter(id)) {
         return hmrTransform(code, {
           bundler: "vite",
           runtime: options?.runtime ?? "react",

--- a/packages/tiny-refresh/src/vite.ts
+++ b/packages/tiny-refresh/src/vite.ts
@@ -19,8 +19,8 @@ export function vitePluginTinyRefresh(options?: {
     // we need to enforce "pre" to see `// @hmr` comments.
     // however this means that transform has to handle raw source code e.g. typescript and jsx.
     enforce: "pre",
-    apply(_config, env) {
-      return env.command === "serve" && !env.ssrBuild;
+    apply(config, env) {
+      return env.command === "serve" && !config.build?.ssr;
     },
     transform(code, id, _options) {
       if (filter(id)) {


### PR DESCRIPTION
I was seeing HMR code is injected for SSR transform while testing in
- https://github.com/hi-ogawa/vite-plugins/pull/123

This is probably because of `ssrBuild` is replaced with `isSsrBuild` in Vite 5.

EDIT: Well, actually I just missed `transformOptions.ssr`...