### PR TITLE
test: use `expectTypeOf` for type testing

### DIFF
--- a/packages/tiny-cli/src/cli.test.ts
+++ b/packages/tiny-cli/src/cli.test.ts
@@ -23,11 +23,13 @@ describe(TinyCli, () => {
           port: arg.number("dev server port", { default: 5172 }),
         },
       },
-      ({ args }) =>
+      ({ args }) => {
         expectTypeOf(args).toEqualTypeOf<{
           host: string;
           port: number;
-        }>()
+        }>();
+        return args;
+      }
     );
 
     cli.defineCommand(

--- a/packages/tiny-cli/src/cli.test.ts
+++ b/packages/tiny-cli/src/cli.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, expectTypeOf, it, vi } from "vitest";
 import { z } from "zod";
 import { TinyCli, TinyCliCommand } from "./cli";
 import { arg } from "./presets";
@@ -24,10 +24,10 @@ describe(TinyCli, () => {
         },
       },
       ({ args }) =>
-        args satisfies {
+        expectTypeOf(args).toEqualTypeOf<{
           host: string;
           port: number;
-        }
+        }>()
     );
 
     cli.defineCommand(

--- a/packages/tiny-cli/src/zod.test.ts
+++ b/packages/tiny-cli/src/zod.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, expectTypeOf, it } from "vitest";
 import { z } from "zod";
 import { TinyCliCommand } from "./cli";
 import { zArg } from "./zod";
@@ -20,12 +20,13 @@ describe(zArg, () => {
           mode: z.coerce.number().default(123).describe("some setting"),
         },
       },
-      ({ args }) =>
-        args satisfies {
+      ({ args }) => {
+        expectTypeOf(args).toEqualTypeOf<{
           files: string[];
           fix: boolean;
           mode: number;
-        }
+        }>();
+      }
     );
 
     expect(cli.help()).toMatchInlineSnapshot(`

--- a/packages/tiny-cli/src/zod.test.ts
+++ b/packages/tiny-cli/src/zod.test.ts
@@ -26,6 +26,7 @@ describe(zArg, () => {
           fix: boolean;
           mode: number;
         }>();
+        return args;
       }
     );
 

--- a/packages/tiny-rpc/src/tests/helper.ts
+++ b/packages/tiny-rpc/src/tests/helper.ts
@@ -1,6 +1,7 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 import { type RequestHandler } from "@hattip/compose";
 import { tinyassert } from "@hiogawa/utils";
+import { expectTypeOf } from "vitest";
 import { z } from "zod";
 import { validateFn } from "../validation";
 
@@ -51,7 +52,7 @@ export function defineTestRpcRoutes() {
     // define with zod validation + input type inference
     incrementCounter: validateFn(z.object({ delta: z.number().default(1) }))(
       (input) => {
-        input satisfies { delta: number };
+        expectTypeOf(input).toEqualTypeOf<{ delta: number }>();
         counter += input.delta;
         return counter;
       }

--- a/packages/tiny-store/src/core.test.ts
+++ b/packages/tiny-store/src/core.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, expectTypeOf, it, vi } from "vitest";
 import { createTinyStore, tinyStoreSelect, tinyStoreTransform } from "./core";
 
 describe(createTinyStore, () => {
@@ -114,10 +114,10 @@ describe(tinyStoreSelect, () => {
       },
     });
     const store2 = tinyStoreSelect(store1, (v) => v.name);
-    store2.set satisfies null;
+    expectTypeOf(store2.set).toBeNull();
 
     const store3 = tinyStoreSelect(store2, (v) => v.first);
-    store3.set satisfies null;
+    expectTypeOf(store3.set).toBeNull();
 
     const snapshots = [store2.get()];
     expect(snapshots.at(-1)).toMatchInlineSnapshot(`

--- a/packages/utils/src/lodash.test.ts
+++ b/packages/utils/src/lodash.test.ts
@@ -315,12 +315,13 @@ describe(objectOmit, () => {
       x: 0,
       y: 1,
     } as const;
-    const result = objectOmit(o, ["x"]) satisfies { y: 1 };
+    const result = objectOmit(o, ["x"]);
     expect(result).toMatchInlineSnapshot(`
       {
         "y": 1,
       }
     `);
+    expectTypeOf(result).toEqualTypeOf<{ readonly y: 1 }>();
   });
 
   it("record", () => {
@@ -328,10 +329,7 @@ describe(objectOmit, () => {
       x: 0,
       y: 1,
     };
-    const result = objectOmit(o, ["x"]) satisfies Omit<
-      Record<string, number>,
-      "x"
-    >;
+    const result = objectOmit(o, ["x"]);
     expect(result).toMatchInlineSnapshot(`
       {
         "y": 1,
@@ -386,13 +384,14 @@ describe(objectKeys, () => {
       x: 0,
       y: 1,
     };
-    const result = objectKeys(o) satisfies ("x" | "y")[];
+    const result = objectKeys(o);
     expect(result).toMatchInlineSnapshot(`
       [
         "x",
         "y",
       ]
     `);
+    expectTypeOf(result).toEqualTypeOf<("x" | "y")[]>();
   });
 });
 
@@ -403,8 +402,7 @@ describe(`${objectEntries.name}/${objectFromEntries.name}`, () => {
       y: 1,
     };
     const entries = objectEntries(o);
-    entries satisfies ["x" | "y", number][];
-    entries satisfies (["x", number] | ["y", number])[];
+    expectTypeOf(entries).toEqualTypeOf<(["x", number] | ["y", number])[]>();
     expect(entries).toMatchInlineSnapshot(`
       [
         [
@@ -418,7 +416,7 @@ describe(`${objectEntries.name}/${objectFromEntries.name}`, () => {
       ]
     `);
     const o2 = objectFromEntries(entries);
-    o2 satisfies Record<"x" | "y", number>;
+    expectTypeOf(o2).toEqualTypeOf<Record<"x" | "y", number>>();
     expect(o2).toMatchInlineSnapshot(`
       {
         "x": 0,
@@ -436,7 +434,7 @@ describe(`${objectMapValues.name}/${objectMapKeys.name}`, () => {
     };
     {
       const result = objectMapValues(o, (v, k) => k.repeat(v));
-      result satisfies Record<"x" | "y", string>;
+      expectTypeOf(result).toEqualTypeOf<Record<"x" | "y", string>>();
       expect(result).toMatchInlineSnapshot(`
         {
           "x": "x",
@@ -446,7 +444,7 @@ describe(`${objectMapValues.name}/${objectMapKeys.name}`, () => {
     }
     {
       const result = objectMapKeys(o, (v) => (v === 1 ? "w" : "z"));
-      result satisfies Record<"z" | "w", number>;
+      expectTypeOf(result).toEqualTypeOf<Record<"z" | "w", number>>();
       expect(result).toMatchInlineSnapshot(`
         {
           "w": 1,

--- a/packages/utils/src/lodash.test.ts
+++ b/packages/utils/src/lodash.test.ts
@@ -466,11 +466,12 @@ describe(`${objectMapValues.name}/${objectMapKeys.name}`, () => {
     };
     {
       const result = objectMapValues(o, (v, k) => (v ? k.repeat(v) : "bad-v"));
-      result satisfies {
+      expectTypeOf(result).toEqualTypeOf<{
         x: string;
-        y?: string;
-        z?: string;
-      };
+        // TODO: these should be optional
+        y: string;
+        z: string;
+      }>();
       expect(result).toMatchInlineSnapshot(`
         {
           "x": "xxx",
@@ -480,7 +481,7 @@ describe(`${objectMapValues.name}/${objectMapKeys.name}`, () => {
     }
     {
       const result = objectMapKeys(o, (v, k) => (v ? k.repeat(v) : "bad-k"));
-      result satisfies Partial<Record<string, number>>;
+      expectTypeOf(result).toEqualTypeOf<Record<string, number | undefined>>();
       expect(result).toMatchInlineSnapshot(`
         {
           "bad-k": undefined,
@@ -516,8 +517,8 @@ describe(isNil, () => {
   it("typing-1", () => {
     const ls = [0, true, false, null, undefined] as const;
 
-    ls.filter(isNil) satisfies (null | undefined)[];
-    ls.filter(isNotNil) satisfies (0 | true | false)[];
+    expectTypeOf(ls.filter(isNil)).toEqualTypeOf<(null | undefined)[]>();
+    expectTypeOf(ls.filter(isNotNil)).toEqualTypeOf<(0 | true | false)[]>();
 
     expect(ls.filter(isNil)).toMatchInlineSnapshot(`
       [
@@ -533,15 +534,15 @@ describe(isNil, () => {
     expect(isNil(x)).toMatchInlineSnapshot("true");
 
     if (isNil(x)) {
-      x satisfies undefined;
+      expectTypeOf(x).toBeUndefined();
     } else {
-      x satisfies number;
+      expectTypeOf(x).toBeNumber();
     }
 
     if (isNotNil(x)) {
-      x satisfies number;
+      expectTypeOf(x).toBeNumber();
     } else {
-      x satisfies undefined;
+      expectTypeOf(x).toBeUndefined();
     }
   });
 });

--- a/packages/utils/src/lodash.test.ts
+++ b/packages/utils/src/lodash.test.ts
@@ -305,7 +305,7 @@ describe(objectPick, () => {
         "x": 0,
       }
     `);
-    expectTypeOf(result).toEqualTypeOf<{ x: number }>();
+    expectTypeOf(result).toEqualTypeOf<{ x: 0 }>();
   });
 });
 

--- a/packages/utils/src/lodash.test.ts
+++ b/packages/utils/src/lodash.test.ts
@@ -305,7 +305,7 @@ describe(objectPick, () => {
         "x": 0,
       }
     `);
-    expectTypeOf(result).toEqualTypeOf<{ x: 0 }>();
+    expectTypeOf(result).toEqualTypeOf<{ x: number }>();
   });
 });
 

--- a/packages/utils/src/lodash.test.ts
+++ b/packages/utils/src/lodash.test.ts
@@ -1,4 +1,12 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  expectTypeOf,
+  it,
+  vi,
+} from "vitest";
 import { LruCache } from "./cache";
 import {
   capitalize,
@@ -277,12 +285,13 @@ describe(objectPick, () => {
       x: 0,
       y: 1,
     } as const;
-    const result = objectPick(o, ["x"]) satisfies { x: 0 };
+    const result = objectPick(o, ["x"]);
     expect(result).toMatchInlineSnapshot(`
       {
         "x": 0,
       }
     `);
+    expectTypeOf(result).toEqualTypeOf<{ readonly x: 0 }>();
   });
 
   it("record", () => {
@@ -290,12 +299,13 @@ describe(objectPick, () => {
       x: 0,
       y: 1,
     };
-    const result = objectPick(o, ["x"]) satisfies { x: number };
+    const result = objectPick(o, ["x"]);
     expect(result).toMatchInlineSnapshot(`
       {
         "x": 0,
       }
     `);
+    expectTypeOf(result).toEqualTypeOf<{ x: number }>();
   });
 });
 

--- a/packages/utils/src/tinyassert.test.ts
+++ b/packages/utils/src/tinyassert.test.ts
@@ -1,5 +1,5 @@
 import process from "node:process";
-import { assert, describe, expect, it } from "vitest";
+import { assert, describe, expect, expectTypeOf, it } from "vitest";
 import { tinyassert } from "./tinyassert";
 
 describe(tinyassert, () => {
@@ -17,9 +17,10 @@ describe(tinyassert, () => {
         .split("\n")
         .slice(0, 3)
         .join("\n")
+        .replaceAll(/ *$/gm, "") // trim trailing
         .replaceAll(process.cwd(), "__CWD__");
       expect(stack).toMatchInlineSnapshot(`
-        "Error: 
+        "Error:
             at boom (__CWD__/src/tinyassert.test.ts:8:7)
             at __CWD__/src/tinyassert.test.ts:11:7"
       `);
@@ -46,7 +47,7 @@ describe(tinyassert, () => {
   it("type guard", () => {
     const maybeNumber = 1 as number | null | undefined;
     tinyassert(maybeNumber);
-    maybeNumber satisfies number;
+    expectTypeOf(maybeNumber).toBeNumber();
   });
 
   it("error without message", () => {


### PR DESCRIPTION
cf. https://github.com/vitest-dev/vitest/issues/4766#issuecomment-1865414158

I just found an interesting pattern on trpc code base. Let's employ this instead of putting `satisfies` in a random place.