### PR TITLE
fix(utils): fix `objectMapValues` typing

### DIFF
--- a/.changeset/chatty-onions-decide.md
+++ b/.changeset/chatty-onions-decide.md
@@ -1,0 +1,5 @@
+---
+"@hiogawa/utils": patch
+---
+
+Fix `objectMapValues` mapped type

--- a/packages/utils/src/lodash.test.ts
+++ b/packages/utils/src/lodash.test.ts
@@ -1,4 +1,12 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  expectTypeOf,
+  it,
+  vi,
+} from "vitest";
 import { LruCache } from "./cache";
 import {
   capitalize,
@@ -458,11 +466,11 @@ describe(`${objectMapValues.name}/${objectMapKeys.name}`, () => {
     };
     {
       const result = objectMapValues(o, (v, k) => (v ? k.repeat(v) : "bad-v"));
-      result satisfies {
+      expectTypeOf(result).toEqualTypeOf<{
         x: string;
         y?: string;
         z?: string;
-      };
+      }>();
       expect(result).toMatchInlineSnapshot(`
         {
           "x": "xxx",

--- a/packages/utils/src/lodash.ts
+++ b/packages/utils/src/lodash.ts
@@ -314,7 +314,7 @@ function objectMapEntries<T extends object, K2 extends PropertyKey, V2>(
 export function objectMapValues<T extends object, V>(
   o: T,
   f: (v: T[keyof T], k: keyof T) => V
-): Record<keyof T, V> {
+): { [k in keyof T]: V } {
   return objectMapEntries(o, ([k, v]) => [k, f(v, k)]);
 }
 


### PR DESCRIPTION
Addressing https://github.com/hi-ogawa/js-utils/pull/190#discussion_r1433423217

I don't want to deal with mapped type intricacy, but I guess this one is simple.