### PR TITLE
feat(utils-node): add `promptAutocomplete`

### DIFF
--- a/.changeset/silly-peas-live.md
+++ b/.changeset/silly-peas-live.md
@@ -1,0 +1,5 @@
+---
+"@hiogawa/utils-node": minor
+---
+
+Add promptAutocomplete

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,5 +3,5 @@ dist
 pnpm-lock.yaml
 pkg
 target
-fixtures
+packages/icheck-ts/fixtures
 .vercel

--- a/misc/pre-release.mjs
+++ b/misc/pre-release.mjs
@@ -17,7 +17,7 @@ async function main() {
     .map((p) => p.path.slice(cwd.length + 1));
 
   const choice = await promptAutocomplete({
-    message: "? Select package directory > ",
+    message: "* Select package directory > ",
     suggest: (input) => {
       return packageDirs.filter((p) => p.includes(input));
     },

--- a/misc/pre-release.mjs
+++ b/misc/pre-release.mjs
@@ -1,6 +1,6 @@
 import process from "node:process";
 import { tinyassert, colors, formatError } from "@hiogawa/utils";
-import { $, promptQuestion } from "@hiogawa/utils-node";
+import { $, promptQuestion, promptAutocomplete } from "@hiogawa/utils-node";
 import fs from "node:fs";
 
 // usage:
@@ -10,9 +10,27 @@ $._.verbose = true;
 const $$ = $.new({ stdio: "inherit" });
 
 async function main() {
-  const packageDir = process.argv[2];
-  tinyassert(packageDir, "missing 'packageDir'");
-  const packageJsonPath = `${packageDir}/package.json`;
+  const cwd = process.cwd();
+  const pnpmLs = await $`pnpm ls --filter '*' --depth -1 --json`;
+  const packageDirs = JSON.parse(pnpmLs)
+    .filter((p) => !p.private)
+    .map((p) => p.path.slice(cwd.length + 1));
+
+  const choice = await promptAutocomplete({
+    message: "? Select package directory > ",
+    suggest: (input) => {
+      return packageDirs.filter((p) => p.includes(input));
+    },
+  });
+  if (!choice.value) {
+    process.exitCode = 1;
+    return;
+  }
+  const packageJsonPath = `${choice.value}/package.json`;
+  tinyassert(
+    fs.existsSync(packageJsonPath),
+    "invalid package: " + packageJsonPath
+  );
 
   // require no diff to start
   const gitStatus = await $`git status --porcelain`;

--- a/packages/utils-node/examples/basic/README.md
+++ b/packages/utils-node/examples/basic/README.md
@@ -1,5 +1,7 @@
 # prompt demo on stackblitz
 
+https://stackblitz.com/github/hi-ogawa/js-utils/tree/main/packages/utils-node/examples/basic?file=index.mjs
+
 ```sh
 npm i
 npm start

--- a/packages/utils-node/examples/basic/README.md
+++ b/packages/utils-node/examples/basic/README.md
@@ -1,0 +1,6 @@
+# prompt demo on stackblitz
+
+```sh
+npm i
+npm start
+```

--- a/packages/utils-node/examples/basic/index.mjs
+++ b/packages/utils-node/examples/basic/index.mjs
@@ -1,0 +1,14 @@
+import { builtinModules } from "node:module";
+import { promptAutocomplete } from "@hiogawa/utils-node";
+
+async function main() {
+  const result = await promptAutocomplete({
+    message: "Select node builtin module > ",
+    suggest: (input) => {
+      return builtinModules.filter((v) => v.includes(input));
+    },
+  });
+  console.log("[RESULT]", result);
+}
+
+main();

--- a/packages/utils-node/examples/basic/package.json
+++ b/packages/utils-node/examples/basic/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@hiogawa/utils-node-demo",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "node ./index.mjs"
+  },
+  "dependencies": {
+    "@hiogawa/utils-node": "latest"
+  }
+}

--- a/packages/utils-node/misc/scrape-keys.mjs
+++ b/packages/utils-node/misc/scrape-keys.mjs
@@ -1,0 +1,15 @@
+import { tinyassert } from "@hiogawa/utils";
+
+async function main() {
+  const url =
+    "https://raw.githubusercontent.com/nodejs/node/ee61c2c6d3e97425b16d6821118084a833e52e29/lib/internal/readline/utils.js";
+  const res = await fetch(url);
+  tinyassert(res.ok);
+  const code = await res.text();
+  const matches = code.matchAll(/key\.name = '(.*?)'/g);
+  let keys = [...matches].map((m) => m[1]);
+  keys = [...new Set(keys)];
+  console.log(JSON.stringify(keys));
+}
+
+main();

--- a/packages/utils-node/package.json
+++ b/packages/utils-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/utils-node",
-  "version": "0.0.1-pre.7",
+  "version": "0.0.1-pre.8",
   "homepage": "https://github.com/hi-ogawa/js-utils/tree/main/packages/utils-node",
   "repository": {
     "type": "git",

--- a/packages/utils-node/package.json
+++ b/packages/utils-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/utils-node",
-  "version": "0.0.1-pre.9",
+  "version": "0.0.1-pre.10",
   "homepage": "https://github.com/hi-ogawa/js-utils/tree/main/packages/utils-node",
   "repository": {
     "type": "git",

--- a/packages/utils-node/package.json
+++ b/packages/utils-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/utils-node",
-  "version": "0.0.1-pre.5",
+  "version": "0.0.1-pre.6",
   "homepage": "https://github.com/hi-ogawa/js-utils/tree/main/packages/utils-node",
   "repository": {
     "type": "git",

--- a/packages/utils-node/package.json
+++ b/packages/utils-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/utils-node",
-  "version": "0.0.1-pre.8",
+  "version": "0.0.1-pre.9",
   "homepage": "https://github.com/hi-ogawa/js-utils/tree/main/packages/utils-node",
   "repository": {
     "type": "git",

--- a/packages/utils-node/package.json
+++ b/packages/utils-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/utils-node",
-  "version": "0.0.1-pre.6",
+  "version": "0.0.1-pre.7",
   "homepage": "https://github.com/hi-ogawa/js-utils/tree/main/packages/utils-node",
   "repository": {
     "type": "git",

--- a/packages/utils-node/src/fixtures/prompt-autocomplete.ts
+++ b/packages/utils-node/src/fixtures/prompt-autocomplete.ts
@@ -13,7 +13,9 @@ async function main() {
     message: "Q. select node builtin module > ",
     suggest: (input) => {
       return builtinModules.filter(v => v.includes(input));
-    }
+    },
+    limit: 30,
+    debug: true,
   });
   console.log("\n[answer]", result);
 }

--- a/packages/utils-node/src/fixtures/prompt-autocomplete.ts
+++ b/packages/utils-node/src/fixtures/prompt-autocomplete.ts
@@ -1,4 +1,5 @@
 import { builtinModules } from "node:module";
+import { colors } from "@hiogawa/utils";
 import { promptAutocomplete } from "../prompt";
 
 /*
@@ -10,12 +11,10 @@ demo
 
 async function main() {
   const result = await promptAutocomplete({
-    message: "Q. select node builtin module > ",
+    message: colors.cyan("?") + " select node builtin module > ",
     suggest: (input) => {
       return builtinModules.filter(v => v.includes(input));
     },
-    limit: 30,
-    debug: true,
   });
   console.log("\n[answer]", result);
 }

--- a/packages/utils-node/src/fixtures/prompt-autocomplete.ts
+++ b/packages/utils-node/src/fixtures/prompt-autocomplete.ts
@@ -10,7 +10,7 @@ demo
 
 async function main() {
   const result = await promptAutocomplete({
-    message: "select node builtin module?",
+    message: "Q. select node builtin module?",
     loadOptions: async (input) => {
       return builtinModules.filter(v => v.includes(input));
     }

--- a/packages/utils-node/src/fixtures/prompt-autocomplete.ts
+++ b/packages/utils-node/src/fixtures/prompt-autocomplete.ts
@@ -1,5 +1,4 @@
 import { builtinModules } from "node:module";
-import { colors } from "@hiogawa/utils";
 import { promptAutocomplete } from "../prompt";
 
 /*
@@ -11,7 +10,7 @@ demo
 
 async function main() {
   const result = await promptAutocomplete({
-    message: colors.cyan("?") + " select node builtin module > ",
+    message: "? select node builtin module > ",
     suggest: (input) => {
       return builtinModules.filter(v => v.includes(input));
     },

--- a/packages/utils-node/src/fixtures/prompt-autocomplete.ts
+++ b/packages/utils-node/src/fixtures/prompt-autocomplete.ts
@@ -1,0 +1,21 @@
+import { builtinModules } from "node:module";
+import { promptAutocomplete } from "../prompt";
+
+/*
+
+demo
+  npx tsx packages/utils-node/src/fixtures/prompt-autocomplete.ts
+
+*/
+
+async function main() {
+  const result = await promptAutocomplete({
+    message: "select node builtin module?",
+    loadOptions: async (input) => {
+      return builtinModules.filter(v => v.includes(input));
+    }
+  });
+  console.log("\n[answer]", result);
+}
+
+main();

--- a/packages/utils-node/src/fixtures/prompt-autocomplete.ts
+++ b/packages/utils-node/src/fixtures/prompt-autocomplete.ts
@@ -10,7 +10,7 @@ demo
 
 async function main() {
   const result = await promptAutocomplete({
-    message: "Q. select node builtin module?",
+    message: "Q. select node builtin module > ",
     loadOptions: async (input) => {
       return builtinModules.filter(v => v.includes(input));
     }

--- a/packages/utils-node/src/fixtures/prompt-autocomplete.ts
+++ b/packages/utils-node/src/fixtures/prompt-autocomplete.ts
@@ -1,4 +1,3 @@
-import { builtinModules } from "node:module";
 import { promptAutocomplete } from "../prompt";
 
 /*
@@ -8,11 +7,15 @@ demo
 
 */
 
+// $ node -e 'console.log(JSON.stringify(require("node:module").builtinModules))'
+// prettier-ignore
+const builtinModules = ["_http_agent","_http_client","_http_common","_http_incoming","_http_outgoing","_http_server","_stream_duplex","_stream_passthrough","_stream_readable","_stream_transform","_stream_wrap","_stream_writable","_tls_common","_tls_wrap","assert","assert/strict","async_hooks","buffer","child_process","cluster","console","constants","crypto","dgram","diagnostics_channel","dns","dns/promises","domain","events","fs","fs/promises","http","http2","https","inspector","module","net","os","path","path/posix","path/win32","perf_hooks","process","punycode","querystring","readline","readline/promises","repl","stream","stream/consumers","stream/promises","stream/web","string_decoder","sys","timers","timers/promises","tls","trace_events","tty","url","util","util/types","v8","vm","worker_threads","zlib"];
+
 async function main() {
   const result = await promptAutocomplete({
     message: "? select node builtin module > ",
     suggest: (input) => {
-      return builtinModules.filter(v => v.includes(input));
+      return builtinModules.filter((v) => v.includes(input));
     },
   });
   console.log("[answer]", result);

--- a/packages/utils-node/src/fixtures/prompt-autocomplete.ts
+++ b/packages/utils-node/src/fixtures/prompt-autocomplete.ts
@@ -11,7 +11,7 @@ demo
 async function main() {
   const result = await promptAutocomplete({
     message: "Q. select node builtin module > ",
-    loadOptions: async (input) => {
+    suggest: (input) => {
       return builtinModules.filter(v => v.includes(input));
     }
   });

--- a/packages/utils-node/src/fixtures/prompt-autocomplete.ts
+++ b/packages/utils-node/src/fixtures/prompt-autocomplete.ts
@@ -15,7 +15,7 @@ async function main() {
       return builtinModules.filter(v => v.includes(input));
     },
   });
-  console.log("\n[answer]", result);
+  console.log("[answer]", result);
 }
 
 main();

--- a/packages/utils-node/src/fixtures/prompt-basic.ts
+++ b/packages/utils-node/src/fixtures/prompt-basic.ts
@@ -1,5 +1,7 @@
 import { promptQuestion } from "../prompt";
 
+// npx tsx packages/utils-node/src/fixtures/prompt-basic.ts
+
 async function main() {
   const answer = await promptQuestion("hello? ");
   console.log("answer:", answer);

--- a/packages/utils-node/src/fixtures/prompt-debug.ts
+++ b/packages/utils-node/src/fixtures/prompt-debug.ts
@@ -1,5 +1,9 @@
 import { colors, createManualPromise } from "@hiogawa/utils";
-import { formatInputCursor, setupKeypressHandler } from "../prompt-utils";
+import {
+  formatInputCursor,
+  getSpecialKey,
+  subscribePromptEvent,
+} from "../prompt-utils";
 
 /*
 
@@ -10,18 +14,19 @@ quick debugging of keypress event
 
 async function main() {
   const manual = createManualPromise<void>();
-  const dispose = setupKeypressHandler(
-    (str, key) => {
-      console.log(JSON.stringify({ str, key }));
-      if (str === "q" || str === "\x03") {
+  const dispose = subscribePromptEvent((e) => {
+    console.log(JSON.stringify(e));
+    if (e.type === "keypress") {
+      const special = getSpecialKey(e.data);
+      if (e.data.input === "q" || special === "abort") {
         manual.resolve();
       }
-    },
-    (input, cursor) => {
-      console.log({ input, cursor });
-      console.log(colors.dim("> ") + formatInputCursor(input, cursor));
     }
-  );
+    if (e.type === "input") {
+      console.log(e.data);
+      console.log(colors.dim("> ") + formatInputCursor(e.data));
+    }
+  });
   console.log(":: echo keypress event ('q' to quit)");
   try {
     await manual;

--- a/packages/utils-node/src/fixtures/prompt-debug.ts
+++ b/packages/utils-node/src/fixtures/prompt-debug.ts
@@ -10,16 +10,19 @@ quick debugging of keypress event
 
 async function main() {
   const manual = createManualPromise<void>();
-  const dispose = setupKeypressHandler((str, key) => {
-    console.log(JSON.stringify({ str, key }));
-    if (str === "q" || str === "\x03") {
-      manual.resolve()
+  const dispose = setupKeypressHandler(
+    (str, key) => {
+      console.log(JSON.stringify({ str, key }));
+      if (str === "q" || str === "\x03") {
+        manual.resolve();
+      }
+    },
+    (input, cursor) => {
+      console.log({ input, cursor });
+      console.log(colors.dim("> ") + formatInputCursor(input, cursor));
     }
-  }, (input, cursor) => {
-    console.log({ input, cursor });
-    console.log(colors.dim("> ") + formatInputCursor(input, cursor));
-  });
-  console.log(":: echo keypress event ('q' to quit)")
+  );
+  console.log(":: echo keypress event ('q' to quit)");
   try {
     await manual;
   } finally {

--- a/packages/utils-node/src/fixtures/prompt-debug.ts
+++ b/packages/utils-node/src/fixtures/prompt-debug.ts
@@ -1,5 +1,5 @@
-import { createManualPromise } from "@hiogawa/utils";
-import { setupKeypressHandler } from "../prompt-utils";
+import { colors, createManualPromise } from "@hiogawa/utils";
+import { formatInputCursor, setupKeypressHandler } from "../prompt-utils";
 
 /*
 
@@ -11,10 +11,13 @@ quick debugging of keypress event
 async function main() {
   const manual = createManualPromise<void>();
   const dispose = setupKeypressHandler((str, key) => {
-    console.log({ str, key });
+    console.log(JSON.stringify({ str, key }));
     if (str === "q" || str === "\x03") {
       manual.resolve()
     }
+  }, (input, cursor) => {
+    console.log({ input, cursor });
+    console.log(colors.dim("> ") + formatInputCursor(input, cursor));
   });
   console.log(":: echo keypress event ('q' to quit)")
   try {

--- a/packages/utils-node/src/fixtures/prompt-debug.ts
+++ b/packages/utils-node/src/fixtures/prompt-debug.ts
@@ -1,0 +1,27 @@
+import { createManualPromise } from "@hiogawa/utils";
+import { setupKeypressHandler } from "../prompt-utils";
+
+/*
+
+quick debugging of keypress event
+  npx tsx packages/utils-node/src/fixtures/prompt-debug.ts
+
+*/
+
+async function main() {
+  const manual = createManualPromise<void>();
+  const dispose = setupKeypressHandler((str, key) => {
+    console.log({ str, key });
+    if (str === "q" || str === "\x03") {
+      manual.resolve()
+    }
+  });
+  console.log(":: echo keypress event ('q' to quit)")
+  try {
+    await manual;
+  } finally {
+    dispose();
+  }
+}
+
+main();

--- a/packages/utils-node/src/prompt-utils.ts
+++ b/packages/utils-node/src/prompt-utils.ts
@@ -20,7 +20,7 @@ export function stripAnsi(s: string) {
 // cf. https://github.com/terkelg/prompts/blob/735603af7c7990ac9efcfba6146967a7dbb15f50/lib/util/clear.js#L5-L6
 export function computeHeight(s: string, width: number) {
   // strip CSI
-  s = stripAnsi(s)
+  s = stripAnsi(s);
 
   // check line wrap
   const wraps = s

--- a/packages/utils-node/src/prompt-utils.ts
+++ b/packages/utils-node/src/prompt-utils.ts
@@ -73,10 +73,10 @@ const SPECIAL_KEYS = [
 export function getSpecialKey({
   input,
   key,
-}: {
-  input?: string;
-  key: KeyInfo;
-}): (typeof SPECIAL_KEYS)[number] | "abort" | undefined {
+}: PromptEventMap["keypress"]):
+  | (typeof SPECIAL_KEYS)[number]
+  | "abort"
+  | undefined {
   // ctrl-c ctrl-z
   if (input === "\x03" || input === "\x1A") {
     return "abort";
@@ -95,20 +95,25 @@ export interface KeyInfo {
   shift: boolean;
 }
 
+export interface PromptEventMap {
+  keypress: {
+    input?: string;
+    key: KeyInfo;
+  };
+  input: {
+    input: string;
+    cursor: number;
+  };
+}
+
 export type PromptEvent =
   | {
       type: "keypress";
-      data: {
-        input?: string;
-        key: KeyInfo;
-      };
+      data: PromptEventMap["keypress"];
     }
   | {
       type: "input";
-      data: {
-        input: string;
-        cursor: number;
-      };
+      data: PromptEventMap["input"];
     };
 
 export function subscribePromptEvent(handler: (e: PromptEvent) => void) {
@@ -166,13 +171,7 @@ export function subscribePromptEvent(handler: (e: PromptEvent) => void) {
   };
 }
 
-export function formatInputCursor({
-  input,
-  cursor,
-}: {
-  input: string;
-  cursor: number;
-}) {
+export function formatInputCursor({ input, cursor }: PromptEventMap["input"]) {
   if (cursor >= input.length) {
     input += " ".repeat(input.length - cursor + 1);
   }

--- a/packages/utils-node/src/prompt-utils.ts
+++ b/packages/utils-node/src/prompt-utils.ts
@@ -1,25 +1,20 @@
 // https://en.wikipedia.org/wiki/ANSI_escape_code#CSI_(Control_Sequence_Introducer)_sequences
 // https://github.com/nodejs/node/blob/a717fa211194b735cdfc1044c7351c6cf96b8783/lib/internal/readline/utils.js
 // https://github.com/terkelg/sisteransi/blob/e219f8672540dde6e92a19e48a3567ef2548d620/src/index.js
-export const ESC = `\x1b`;
-export const CSI = `${ESC}[`;
-export const kClearToLineBeginning = `${CSI}1K`;
-export const kClearToLineEnd = `${CSI}1K`;
-export const kClearLine = `${CSI}2K`;
-export const kClearScreenDown = `${CSI}0J`;
-export const kClearAll = `${CSI}2J`;
+export const CSI = "\x1b[";
 
-export function cursorTo(x: number, y?: number) {
-  return typeof y !== "number" ? `${CSI}${x + 1}G` : `${CSI}${y + 1};${x + 1}H`;
+// cf. https://github.com/terkelg/prompts/blob/735603af7c7990ac9efcfba6146967a7dbb15f50/lib/util/clear.js#L5-L6
+export function computeHeight(s: string, width: number) {
+  // strip CSI
+  const s2 = s.replaceAll(/\x1b\[\d*[A-Za-z]/g, "");
+
+  // check line wrap
+  const wraps = s2
+    .split("\n")
+    .map((line) => computeLineWrap(line.length, width));
+  return wraps.reduce((x, y) => x + y);
 }
 
-export function moveCursor(dx: number, dy: number) {
-  return [
-    dx < 0 && `${CSI}${-dx}D`,
-    dx > 0 && `${CSI}${dx}C`,
-    dy < 0 && `${CSI}${-dy}A`,
-    dy > 0 && `${CSI}${dy}B`,
-  ]
-    .filter(Boolean)
-    .join("");
+function computeLineWrap(l: number, w: number) {
+  return Math.floor(Math.max((l - 1) / w, 0) + 1);
 }

--- a/packages/utils-node/src/prompt-utils.ts
+++ b/packages/utils-node/src/prompt-utils.ts
@@ -1,12 +1,13 @@
 // https://en.wikipedia.org/wiki/ANSI_escape_code#CSI_(Control_Sequence_Introducer)_sequences
 // https://github.com/nodejs/node/blob/a717fa211194b735cdfc1044c7351c6cf96b8783/lib/internal/readline/utils.js
 // https://github.com/terkelg/sisteransi/blob/e219f8672540dde6e92a19e48a3567ef2548d620/src/index.js
-const kEscape = `\x1b`;
-const CSI = `${kEscape}[`;
+export const ESC = `\x1b`;
+export const CSI = `${ESC}[`;
 export const kClearToLineBeginning = `${CSI}1K`;
 export const kClearToLineEnd = `${CSI}1K`;
 export const kClearLine = `${CSI}2K`;
 export const kClearScreenDown = `${CSI}0J`;
+export const kClearAll = `${CSI}2J`;
 
 export function cursorTo(x: number, y?: number) {
   return typeof y !== "number" ? `${CSI}${x + 1}G` : `${CSI}${y + 1};${x + 1}H`;

--- a/packages/utils-node/src/prompt-utils.ts
+++ b/packages/utils-node/src/prompt-utils.ts
@@ -1,0 +1,26 @@
+// https://en.wikipedia.org/wiki/ANSI_escape_code#CSI_(Control_Sequence_Introducer)_sequences
+// https://github.com/nodejs/node/blame/a717fa211194b735cdfc1044c7351c6cf96b8783/lib/internal/readline/utils.js#L22-L29
+// https://github.com/terkelg/sisteransi/blob/e219f8672540dde6e92a19e48a3567ef2548d620/src/index.js
+const kEscape = `\x1b`;
+const CSI = `${kEscape}[`;
+export const kClearToLineBeginning = `${CSI}1K`;
+export const kClearToLineEnd = `${CSI}1K`;
+export const kClearLine = `${CSI}2K`;
+export const kClearScreenDown = `${CSI}0J`;
+export const kSave = `${kEscape}7`;
+export const kRestore = `${kEscape}8`;
+
+export function cursorTo(x: number, y?: number) {
+  return typeof y !== "number" ? `${CSI}${x + 1}G` : `${CSI}${y + 1};${x + 1}H`;
+}
+
+export function moveCursor(dx: number, dy: number) {
+  return [
+    dx < 0 && `${CSI}${-dx}D`,
+    dx > 0 && `${CSI}${dx}C`,
+    dy < 0 && `${CSI}${-dy}A`,
+    dy > 0 && `${CSI}${dy}A`,
+  ]
+    .filter(Boolean)
+    .join("");
+}

--- a/packages/utils-node/src/prompt-utils.ts
+++ b/packages/utils-node/src/prompt-utils.ts
@@ -7,6 +7,16 @@ import { colors, includesGuard } from "@hiogawa/utils";
 // https://github.com/terkelg/sisteransi/blob/e219f8672540dde6e92a19e48a3567ef2548d620/src/index.js
 export const CSI = "\x1b[";
 
+// CSI (num) (char)
+// CSI (num) ; (num) (char)
+// CSI ? (num) (char)
+export const CSI_RE = /\x1b\[\??\d*;?\d*[A-Za-z]/g;
+
+// poor-man's strip ansi code
+export function stripAnsi(s: string) {
+  return s.replaceAll(CSI_RE, "");
+}
+
 // cf. https://github.com/terkelg/prompts/blob/735603af7c7990ac9efcfba6146967a7dbb15f50/lib/util/clear.js#L5-L6
 export function computeHeight(s: string, width: number) {
   // strip CSI
@@ -86,6 +96,7 @@ export interface KeyInfo {
 // https://github.com/natemoo-re/clack/blob/90f8e3d762e96fde614fdf8da0529866649fafe2/packages/core/src/prompts/prompt.ts#L93
 // https://github.com/terkelg/prompts/blob/735603af7c7990ac9efcfba6146967a7dbb15f50/lib/elements/prompt.js#L22-L23
 // TODO: rename to setupReadlineHandler
+// TODO: refactor to event emitter style API?
 export function setupKeypressHandler(
   handler: (str: string | undefined, key: KeyInfo) => void,
   inputHandler?: (input: string, cursor: number) => void

--- a/packages/utils-node/src/prompt-utils.ts
+++ b/packages/utils-node/src/prompt-utils.ts
@@ -59,10 +59,13 @@ const SPECIAL_KEYS = [
   "paste-end",
 ] as const;
 
-export function getSpecialKey(str: string | undefined, key: KeyInfo) {
+export function getSpecialKey(
+  str: string | undefined,
+  key: KeyInfo
+): (typeof SPECIAL_KEYS)[number] | "abort" | undefined {
   // ctrl-c ctrl-z
   if (str === "\x03" || str === "\x1A") {
-    return "abort" as const;
+    return "abort";
   }
   if (includesGuard(SPECIAL_KEYS, key.name)) {
     return key.name;

--- a/packages/utils-node/src/prompt-utils.ts
+++ b/packages/utils-node/src/prompt-utils.ts
@@ -1,5 +1,5 @@
 // https://en.wikipedia.org/wiki/ANSI_escape_code#CSI_(Control_Sequence_Introducer)_sequences
-// https://github.com/nodejs/node/blame/a717fa211194b735cdfc1044c7351c6cf96b8783/lib/internal/readline/utils.js#L22-L29
+// https://github.com/nodejs/node/blob/a717fa211194b735cdfc1044c7351c6cf96b8783/lib/internal/readline/utils.js
 // https://github.com/terkelg/sisteransi/blob/e219f8672540dde6e92a19e48a3567ef2548d620/src/index.js
 const kEscape = `\x1b`;
 const CSI = `${kEscape}[`;
@@ -7,8 +7,6 @@ export const kClearToLineBeginning = `${CSI}1K`;
 export const kClearToLineEnd = `${CSI}1K`;
 export const kClearLine = `${CSI}2K`;
 export const kClearScreenDown = `${CSI}0J`;
-export const kSave = `${kEscape}7`;
-export const kRestore = `${kEscape}8`;
 
 export function cursorTo(x: number, y?: number) {
   return typeof y !== "number" ? `${CSI}${x + 1}G` : `${CSI}${y + 1};${x + 1}H`;
@@ -19,7 +17,7 @@ export function moveCursor(dx: number, dy: number) {
     dx < 0 && `${CSI}${-dx}D`,
     dx > 0 && `${CSI}${dx}C`,
     dy < 0 && `${CSI}${-dy}A`,
-    dy > 0 && `${CSI}${dy}A`,
+    dy > 0 && `${CSI}${dy}B`,
   ]
     .filter(Boolean)
     .join("");

--- a/packages/utils-node/src/prompt-utils.ts
+++ b/packages/utils-node/src/prompt-utils.ts
@@ -1,3 +1,6 @@
+import readline from "node:readline";
+import { includesGuard } from "@hiogawa/utils";
+
 // https://en.wikipedia.org/wiki/ANSI_escape_code#CSI_(Control_Sequence_Introducer)_sequences
 // https://github.com/nodejs/node/blob/a717fa211194b735cdfc1044c7351c6cf96b8783/lib/internal/readline/utils.js
 // https://github.com/terkelg/sisteransi/blob/e219f8672540dde6e92a19e48a3567ef2548d620/src/index.js
@@ -17,4 +20,85 @@ export function computeHeight(s: string, width: number) {
 
 function computeLineWrap(l: number, w: number) {
   return Math.floor(Math.max((l - 1) / w, 0) + 1);
+}
+
+// extracted from https://github.com/nodejs/node/blob/ee61c2c6d3e97425b16d6821118084a833e52e29/lib/internal/readline/utils.js#L222 by
+//   node packages/utils-node/misc/scrape-keys.mjs
+const SPECIAL_KEYS = [
+  "f1",
+  "f2",
+  "f3",
+  "f4",
+  "f5",
+  "f6",
+  "f7",
+  "f8",
+  "f9",
+  "f10",
+  "f11",
+  "f12",
+  "up",
+  "down",
+  "right",
+  "left",
+  "clear",
+  "end",
+  "home",
+  "insert",
+  "delete",
+  "pageup",
+  "pagedown",
+  "tab",
+  "undefined",
+  "return",
+  "enter",
+  "backspace",
+  "escape",
+  "space",
+  "paste-start",
+  "paste-end",
+] as const;
+
+export function getSpecialKey(str: string | undefined, key: KeyInfo) {
+  // ctrl-c ctrl-z
+  if (str === "\x03" || str === "\x1A") {
+    return "abort" as const;
+  }
+  if (includesGuard(SPECIAL_KEYS, key.name)) {
+    return key.name;
+  }
+  return;
+}
+
+export interface KeyInfo {
+  sequence: string;
+  name: string;
+  ctrl: boolean;
+  meta: boolean;
+  shift: boolean;
+}
+
+export function setupKeypressHandler(
+  handler: (str: string | undefined, key: KeyInfo) => void
+) {
+  // setup
+  const stdin = process.stdin;
+  const rl = readline.createInterface({
+    input: stdin,
+  });
+  readline.emitKeypressEvents(stdin, rl);
+  let previousRawMode = stdin.isRaw;
+  if (stdin.isTTY) {
+    stdin.setRawMode(true);
+  }
+  stdin.on("keypress", handler);
+
+  // teardown
+  return () => {
+    stdin.off("keypress", handler);
+    if (stdin.isTTY) {
+      stdin.setRawMode(previousRawMode);
+    }
+    rl.close();
+  };
 }

--- a/packages/utils-node/src/prompt-utils.ts
+++ b/packages/utils-node/src/prompt-utils.ts
@@ -20,10 +20,10 @@ export function stripAnsi(s: string) {
 // cf. https://github.com/terkelg/prompts/blob/735603af7c7990ac9efcfba6146967a7dbb15f50/lib/util/clear.js#L5-L6
 export function computeHeight(s: string, width: number) {
   // strip CSI
-  const s2 = s.replaceAll(/\x1b\[\d*[A-Za-z]/g, "");
+  s = stripAnsi(s)
 
   // check line wrap
-  const wraps = s2
+  const wraps = s
     .split("\n")
     .map((line) => computeLineWrap(line.length, width));
   return wraps.reduce((x, y) => x + y);

--- a/packages/utils-node/src/prompt.test.ts
+++ b/packages/utils-node/src/prompt.test.ts
@@ -38,6 +38,7 @@ describe(promptAutocomplete, () => {
           _stream_passthrough
           _stream_readable
           _stream_transform
+        [1/66]
       "
     `);
 
@@ -45,14 +46,15 @@ describe(promptAutocomplete, () => {
     await waitForStable(proc.child.stdout);
     expect("?" + stripSnap(proc.stdout).split("?").at(-1))
       .toMatchInlineSnapshot(`
-      "? select node builtin module > promises
-        > dns/promises
-          fs/promises
-          readline/promises
-          stream/promises
-          timers/promises
-      "
-    `);
+        "? select node builtin module > promises
+          > dns/promises
+            fs/promises
+            readline/promises
+            stream/promises
+            timers/promises
+          [1/5]
+        "
+      `);
 
     proc.child.stdin.write("\x1b[B".repeat(2));
     await waitForStable(proc.child.stdout);
@@ -64,6 +66,7 @@ describe(promptAutocomplete, () => {
           > readline/promises
             stream/promises
             timers/promises
+          [3/5]
         "
       `);
 

--- a/packages/utils-node/src/prompt.test.ts
+++ b/packages/utils-node/src/prompt.test.ts
@@ -28,42 +28,53 @@ describe(promptAutocomplete, () => {
     await waitForStable(proc.child.stdout);
     expect(stripSnap(proc.stdout)).toMatchInlineSnapshot(`
       "? select node builtin module >
+        > _http_agent
+          _http_client
+          _http_common
+          _http_incoming
+          _http_outgoing
+          _http_server
+          _stream_duplex
+          _stream_passthrough
+          _stream_readable
+          _stream_transform
       "
     `);
-
-    // TODO: why suggestions not showing up?
 
     proc.child.stdin.write("promises");
     await waitForStable(proc.child.stdout);
-    expect(stripSnap(proc.stdout)).toMatchInlineSnapshot(`
-      "? select node builtin module >
-      ? select node builtin module > promises
-      ? select node builtin module > promises
-      ? select node builtin module > promises
-      ? select node builtin module > promises
-      ? select node builtin module > promises
-      ? select node builtin module > promises
-      ? select node builtin module > promises
-      ? select node builtin module > promises
+    expect("?" + stripSnap(proc.stdout).split("?").at(-1))
+      .toMatchInlineSnapshot(`
+      "? select node builtin module > promises
+        > dns/promises
+          fs/promises
+          readline/promises
+          stream/promises
+          timers/promises
       "
     `);
 
+    proc.child.stdin.write("\x1b[B".repeat(2));
+    await waitForStable(proc.child.stdout);
+    expect("?" + stripSnap(proc.stdout).split("?").at(-1))
+      .toMatchInlineSnapshot(`
+        "? select node builtin module > promises
+            dns/promises
+            fs/promises
+          > readline/promises
+            stream/promises
+            timers/promises
+        "
+      `);
+
     proc.child.stdin.write("\n");
     await waitForStable(proc.child.stdout);
-    expect(stripSnap(proc.stdout)).toMatchInlineSnapshot(`
-      "? select node builtin module >
-      ? select node builtin module > promises
-      ? select node builtin module > promises
-      ? select node builtin module > promises
-      ? select node builtin module > promises
-      ? select node builtin module > promises
-      ? select node builtin module > promises
-      ? select node builtin module > promises
-      ? select node builtin module > promises
-      ? select node builtin module > promises
-      [answer] { input: 'promises', value: 'dns/promises' }
-      "
-    `);
+    expect("?" + stripSnap(proc.stdout).split("?").at(-1))
+      .toMatchInlineSnapshot(`
+        "? select node builtin module > promises
+        [answer] { input: 'promises', value: 'readline/promises' }
+        "
+      `);
   });
 });
 

--- a/packages/utils-node/src/prompt.test.ts
+++ b/packages/utils-node/src/prompt.test.ts
@@ -1,30 +1,85 @@
-import { sleep, tinyassert } from "@hiogawa/utils";
+import type { Readable } from "stream";
+import { createManualPromise, debounce, tinyassert } from "@hiogawa/utils";
 import { describe, expect, it } from "vitest";
-import { promptQuestion } from "./prompt";
+import { promptAutocomplete, promptQuestion } from "./prompt";
+import { stripAnsi } from "./prompt-utils";
 import { $ } from "./script";
 
 describe(promptQuestion, () => {
   it("basic", async () => {
     const proc = $`pnpm exec tsx ./src/fixtures/prompt-basic.ts`;
     tinyassert(proc.child.stdin);
+    tinyassert(proc.child.stdout);
 
-    await retry(() => tinyassert(proc.stdout.includes("hello?")));
+    await waitForStable(proc.child.stdout);
     expect(proc.stdout).toMatchInlineSnapshot(`"hello? "`);
 
-    proc.child.stdin.end("hi\n");
+    proc.child.stdin.write("hi\n");
     expect(await proc).toMatchInlineSnapshot(`"hello? answer: hi"`);
   });
 });
 
-async function retry<T>(f: () => T): Promise<Awaited<T>> {
-  let error: unknown;
-  for (const interval of [100, 250, 500, 1000]) {
-    try {
-      return await f();
-    } catch (e) {
-      error = e;
-    }
-    await sleep(interval);
+describe(promptAutocomplete, () => {
+  it("basic", async () => {
+    const proc = $`pnpm exec tsx ./src/fixtures/prompt-autocomplete.ts`;
+    tinyassert(proc.child.stdin);
+    tinyassert(proc.child.stdout);
+
+    await waitForStable(proc.child.stdout);
+    expect(stripSnap(proc.stdout)).toMatchInlineSnapshot(`
+      "? select node builtin module >
+      "
+    `);
+
+    // TODO: why suggestions not showing up?
+
+    proc.child.stdin.write("promises");
+    await waitForStable(proc.child.stdout);
+    expect(stripSnap(proc.stdout)).toMatchInlineSnapshot(`
+      "? select node builtin module >
+      ? select node builtin module > promises
+      ? select node builtin module > promises
+      ? select node builtin module > promises
+      ? select node builtin module > promises
+      ? select node builtin module > promises
+      ? select node builtin module > promises
+      ? select node builtin module > promises
+      ? select node builtin module > promises
+      "
+    `);
+
+    proc.child.stdin.write("\n");
+    await waitForStable(proc.child.stdout);
+    expect(stripSnap(proc.stdout)).toMatchInlineSnapshot(`
+      "? select node builtin module >
+      ? select node builtin module > promises
+      ? select node builtin module > promises
+      ? select node builtin module > promises
+      ? select node builtin module > promises
+      ? select node builtin module > promises
+      ? select node builtin module > promises
+      ? select node builtin module > promises
+      ? select node builtin module > promises
+      ? select node builtin module > promises
+      [answer] { input: 'promises', value: 'dns/promises' }
+      "
+    `);
+  });
+});
+
+async function waitForStable(readable: Readable, ms: number = 200) {
+  const manual = createManualPromise<void>();
+  const resolve = debounce(() => manual.resolve(), ms);
+  readable.on("data", resolve);
+  try {
+    await manual;
+  } finally {
+    readable.off("data", resolve);
   }
-  throw error;
+}
+
+function stripSnap(v: string) {
+  v = stripAnsi(v);
+  v = v.replaceAll(/ *$/gm, ""); // strip trailing line
+  return v;
 }

--- a/packages/utils-node/src/prompt.test.ts
+++ b/packages/utils-node/src/prompt.test.ts
@@ -74,7 +74,7 @@ describe(promptAutocomplete, () => {
     await waitForStable(proc.child.stdout);
     expect("?" + stripSnap(proc.stdout).split("?").at(-1))
       .toMatchInlineSnapshot(`
-        "? select node builtin module > promises
+        "? select node builtin module > readline/promises
         [answer] { input: 'promises', value: 'readline/promises' }
         "
       `);

--- a/packages/utils-node/src/prompt.ts
+++ b/packages/utils-node/src/prompt.ts
@@ -47,7 +47,7 @@ export async function promptAutocomplete(options: {
   let done = false;
   let offset = 0;
   const stdoutRows = process.stdout.rows ?? 20;
-  const stdoutColumns = process.stdout.rows ?? 80;
+  const stdoutColumns = process.stdout.columns ?? 80;
   const limit = options.limit ?? Math.min(10, stdoutRows - 5);
   const hideCursor = options.hideCursor ?? true;
 

--- a/packages/utils-node/src/prompt.ts
+++ b/packages/utils-node/src/prompt.ts
@@ -44,7 +44,6 @@ export async function promptAutocomplete(options: {
   let suggestions: string[] = [];
   let suggestionIndex = 0;
   let done = false;
-  let lastContent: string | undefined;
   const limit = options.limit ?? 10;
   const debug = options.debug ?? false;
 
@@ -56,16 +55,6 @@ export async function promptAutocomplete(options: {
       suggestions.length - 1
     );
     value = suggestions[suggestionIndex];
-
-    // clear last render
-    // (TODO: this approach doesn't clear properly either when terminal height is smaller than content. this happens with `prompts` package too)
-    if (lastContent) {
-      const height = computeHeight(lastContent, process.stdout.columns);
-      await write(
-        (`${CSI}2K` + `${CSI}1A`).repeat(height - 1) + `${CSI}2K` + `${CSI}1G`
-      );
-      lastContent = undefined;
-    }
 
     // render
     let content = options.message + input;
@@ -84,8 +73,13 @@ export async function promptAutocomplete(options: {
         .join(""),
     ].join("");
 
-    await write(content);
-    lastContent = content;
+    // 1. clean screen below
+    // 2. write content
+    // 3. reset cursor position (TODO: terminal cannot go up "height" when it exceeds termianl height)
+    const height = computeHeight(content, process.stdout.columns);
+    await write(
+      [`${CSI}0J`, content, `${CSI}1A`.repeat(height - 1), `${CSI}1G`].join("")
+    );
   }
 
   // TODO: async handler race condition

--- a/packages/utils-node/src/prompt.ts
+++ b/packages/utils-node/src/prompt.ts
@@ -78,7 +78,7 @@ export async function promptAutocomplete(options: {
 
   async function render() {
     if (done) {
-      await write(`${CSI}0J` + options.message + input + "\n");
+      await write(`${CSI}0J` + options.message + (value ?? input) + "\n");
       return;
     }
 

--- a/packages/utils-node/src/prompt.ts
+++ b/packages/utils-node/src/prompt.ts
@@ -63,13 +63,13 @@ export async function promptAutocomplete(options: {
       return;
     }
 
-    // TODO: highlight `suggestionIndex`
+    // TODO: scroll page
     content = [
       content,
       "\n",
       suggestions
         .slice(0, limit)
-        .map((v) => `    ${v}\n`)
+        .map((v, i) => `  ${i === suggestionIndex ? "*" : " "} ${v}\n`)
         .join(""),
     ].join("");
 

--- a/packages/utils-node/src/prompt.ts
+++ b/packages/utils-node/src/prompt.ts
@@ -44,7 +44,7 @@ export async function promptAutocomplete(config: {
   async function render() {
     const options = await config.loadOptions(input);
 
-    const part1 = config.message + " > " + input;
+    const part1 = config.message + input;
     if (done) {
       await write(part1);
       return;

--- a/packages/utils-node/src/prompt.ts
+++ b/packages/utils-node/src/prompt.ts
@@ -1,9 +1,6 @@
 import readline from "node:readline";
 import { createManualPromise } from "@hiogawa/utils";
-import {
-  cursorTo,
-  kClearLine,
-} from "./prompt-utils";
+import { cursorTo, kClearLine } from "./prompt-utils";
 
 // cf. https://github.com/google/zx/blob/956dcc3bbdd349ac4c41f8db51add4efa2f58456/src/goods.ts#L83
 export async function promptQuestion(query: string): Promise<string> {
@@ -52,7 +49,7 @@ export async function promptAutocomplete(config: {
   }
 
   const dispose = setupKeypressHandler(async (str: string, key: KeyInfo) => {
-    // TODO: move command
+    // TODO: more special keys
     // https://github.com/terkelg/prompts/blob/735603af7c7990ac9efcfba6146967a7dbb15f50/lib/util/action.js#L18-L26
     if (key.name === "escape" || (key.ctrl && key.name === "c")) {
       manual.resolve({ input, value: "", ok: false });

--- a/packages/utils-node/src/prompt.ts
+++ b/packages/utils-node/src/prompt.ts
@@ -29,7 +29,6 @@ export async function promptQuestion(query: string): Promise<string> {
   }
 }
 
-// cf. https://github.com/terkelg/prompts/blob/735603af7c7990ac9efcfba6146967a7dbb15f50/lib/elements/autocomplete.js#L97-L108
 export async function promptAutocomplete(options: {
   message: string;
   suggest: (input: string) => string[] | Promise<string[]>;

--- a/packages/utils-node/src/prompt.ts
+++ b/packages/utils-node/src/prompt.ts
@@ -35,6 +35,7 @@ export async function promptAutocomplete(options: {
   suggest: (input: string) => string[] | Promise<string[]>;
   limit?: number;
   hideCursor?: boolean; // convenient for debugging
+  hideCount?: boolean;
 }) {
   const write = promisify(process.stdout.write.bind(process.stdout));
   const manual = createManualPromise<void>();
@@ -77,7 +78,7 @@ export async function promptAutocomplete(options: {
 
   async function render() {
     if (done) {
-      await write(`${CSI}0J` + options.message + input);
+      await write(`${CSI}0J` + options.message + input + "\n");
       return;
     }
 
@@ -87,6 +88,9 @@ export async function promptAutocomplete(options: {
       .slice(offset, offset + limit)
       .map((v, i) => `  ${i + offset === suggestionIndex ? ">" : " "} ${v}\n`)
       .join("");
+    if (!options.hideCount) {
+      content += `  [${suggestionIndex + 1}/${suggestions.length}]\n`;
+    }
 
     // TODO: vscode's terminal has funky behavior when content height exceeds terminal height?
     // TODO: IME (e.g Japanese input) cursor is currently not considered.

--- a/packages/utils-node/src/prompt.ts
+++ b/packages/utils-node/src/prompt.ts
@@ -86,7 +86,7 @@ export async function promptAutocomplete(options: {
       .map((v, i) => `  ${i + offset === suggestionIndex ? ">" : " "} ${v}\n`)
       .join("");
 
-    // TODO: vscode's terminal have funky behavior when content height exceeds terminal height?
+    // TODO: vscode's terminal has funky behavior when content height exceeds terminal height?
     // TODO: IME (e.g Japanese input) cursor is currently not considered.
     const height = computeHeight(content, process.stdout.columns);
     await write(

--- a/packages/utils-node/src/prompt.ts
+++ b/packages/utils-node/src/prompt.ts
@@ -46,7 +46,9 @@ export async function promptAutocomplete(options: {
   let suggestionIndex = 0;
   let done = false;
   let offset = 0;
-  const limit = options.limit ?? Math.min(10, process.stdout.rows - 5);
+  const stdoutRows = process.stdout.rows ?? 20;
+  const stdoutColumns = process.stdout.rows ?? 80;
+  const limit = options.limit ?? Math.min(10, stdoutRows - 5);
   const hideCursor = options.hideCursor ?? true;
 
   async function updateSuggestions() {
@@ -88,7 +90,7 @@ export async function promptAutocomplete(options: {
 
     // TODO: vscode's terminal has funky behavior when content height exceeds terminal height?
     // TODO: IME (e.g Japanese input) cursor is currently not considered.
-    const height = computeHeight(content, process.stdout.columns);
+    const height = computeHeight(content, stdoutColumns);
     await write(
       // clear below + content + cursor up by "height"
       `${CSI}0J` + content + `${CSI}1A`.repeat(height - 1) + `${CSI}1G`

--- a/packages/utils-node/src/prompt.ts
+++ b/packages/utils-node/src/prompt.ts
@@ -34,7 +34,7 @@ export async function promptAutocomplete(options: {
   message: string;
   suggest: (input: string) => string[] | Promise<string[]>;
   limit?: number;
-  hideCursor?: boolean;
+  hideCursor?: boolean; // convenient for debugging
 }) {
   const write = promisify(process.stdout.write.bind(process.stdout));
   const manual = createManualPromise<void>();

--- a/packages/utils-node/src/prompt.ts
+++ b/packages/utils-node/src/prompt.ts
@@ -1,5 +1,9 @@
 import readline from "node:readline";
 import { createManualPromise } from "@hiogawa/utils";
+import {
+  cursorTo,
+  kClearLine,
+} from "./prompt-utils";
 
 // cf. https://github.com/google/zx/blob/956dcc3bbdd349ac4c41f8db51add4efa2f58456/src/goods.ts#L83
 export async function promptQuestion(query: string): Promise<string> {
@@ -19,4 +23,98 @@ export async function promptQuestion(query: string): Promise<string> {
   } finally {
     rl.close();
   }
+}
+
+// cf. https://github.com/terkelg/prompts/blob/735603af7c7990ac9efcfba6146967a7dbb15f50/lib/elements/autocomplete.js#L97-L108
+export async function promptAutocomplete(config: {
+  message: string;
+  loadOptions: (input: string) => Promise<string[]>;
+}): Promise<AutocompleteResult> {
+  const manual = createManualPromise<AutocompleteResult>();
+  let input = "";
+  let output = "";
+
+  async function render() {
+    const options = await config.loadOptions(input);
+    // TODO: clear last output
+    // TODO: move cursor
+    output = [
+      kClearLine,
+      cursorTo(0),
+      config.message + " > " + input,
+      "\n",
+      options
+        .slice(0, 10)
+        .map((v) => `    ${v}\n`)
+        .join(""),
+    ].join("");
+    process.stdout.write(output);
+  }
+
+  const dispose = setupKeypressHandler(async (str: string, key: KeyInfo) => {
+    // TODO: move command
+    // https://github.com/terkelg/prompts/blob/735603af7c7990ac9efcfba6146967a7dbb15f50/lib/util/action.js#L18-L26
+    if (key.name === "escape" || (key.ctrl && key.name === "c")) {
+      manual.resolve({ input, value: "", ok: false });
+      return;
+    }
+    if (key.name === "return" || key.name === "enter") {
+      manual.resolve({ input, value: input, ok: true });
+      return;
+    }
+    if (key.name === "backspace") {
+      input = input.slice(0, -1);
+    } else {
+      input += str;
+    }
+    render();
+  });
+
+  try {
+    render();
+    return await manual.promise;
+  } finally {
+    dispose();
+  }
+}
+
+interface AutocompleteResult {
+  input: string;
+  value: string;
+  ok: boolean;
+}
+
+//
+// keypress event utils
+//
+
+interface KeyInfo {
+  sequence: string;
+  name: string;
+  ctrl: boolean;
+  meta: boolean;
+  shift: boolean;
+}
+
+function setupKeypressHandler(handler: (str: string, key: KeyInfo) => void) {
+  // setup
+  const stdin = process.stdin;
+  const rl = readline.createInterface({
+    input: stdin,
+  });
+  readline.emitKeypressEvents(stdin, rl);
+  let previousRawMode = stdin.isRaw;
+  if (stdin.isTTY) {
+    stdin.setRawMode(true);
+  }
+  stdin.on("keypress", handler);
+
+  // teardown
+  return () => {
+    stdin.off("keypress", handler);
+    if (stdin.isTTY) {
+      stdin.setRawMode(previousRawMode);
+    }
+    rl.close();
+  };
 }

--- a/packages/utils-node/src/prompt.ts
+++ b/packages/utils-node/src/prompt.ts
@@ -48,7 +48,7 @@ export async function promptAutocomplete(config: {
     // TODO: pagination based on process.stdout.rows?
     const part1 = config.message + " > " + input;
     const part2 = options
-      .slice(0, 10)
+      .slice(0, 20)
       .map((v) => `    ${v}\n`)
       .join("");
 
@@ -58,11 +58,18 @@ export async function promptAutocomplete(config: {
 
     // restore last position and clear only lines below
     if (!first) {
-      await write(`${ESC}8`);
+      // ESC;
+      // await write(`${ESC}8`);
+      // await write(`${CSI}s`);
     }
+    // ESC;
+
     await write(`${ESC}7`);
+    // await write(`${CSI}s`);
     output = [`${CSI}0J`, cursorTo(0), part1, "\n", part2].join("");
     await write(output);
+    // await write(`${CSI}u`);
+    await write(`${ESC}8`);
 
     // clean only single line
     // (TODO: this doesn't work when prompt becomes more than one line)
@@ -98,14 +105,18 @@ export async function promptAutocomplete(config: {
   });
 
   try {
-    await write(`${CSI}?25l`); // hide cursor
+    // await write(`${CSI}1J`);
+    await write(`${CSI}2J`);
+    // await write(`${CSI}2S`);
+
+    // await write(`${CSI}?25l`); // hide cursor
     render();
     return await manual.promise;
   } finally {
     // TODO: render final result
     // render()
     await write(`${CSI}0J`); // clean below
-    await write(`${CSI}?25h`); // show cursor
+    // await write(`${CSI}?25h`); // show cursor
     dispose();
   }
 }

--- a/packages/utils-node/src/prompt.ts
+++ b/packages/utils-node/src/prompt.ts
@@ -1,6 +1,6 @@
 import readline from "node:readline";
 import { createManualPromise } from "@hiogawa/utils";
-import { CSI, ESC, cursorTo } from "./prompt-utils";
+import { CSI, cursorTo } from "./prompt-utils";
 
 // cf. https://github.com/google/zx/blob/956dcc3bbdd349ac4c41f8db51add4efa2f58456/src/goods.ts#L83
 export async function promptQuestion(query: string): Promise<string> {
@@ -39,8 +39,6 @@ export async function promptAutocomplete(config: {
     await manual;
   }
 
-  let first = true;
-
   // TODO: async handler race condition
   async function render() {
     const options = await config.loadOptions(input);
@@ -53,36 +51,12 @@ export async function promptAutocomplete(config: {
       .join("");
 
     // simple clear full screen
-    // output = [`${CSI}2J`, cursorTo(0, 0), part1, "\n", part2].join("");
-    // await write(output);
-
-    // restore last position and clear only lines below
-    if (!first) {
-      // ESC;
-      // await write(`${ESC}8`);
-      // await write(`${CSI}s`);
-    }
-    // ESC;
-
-    await write(`${ESC}7`);
-    // await write(`${CSI}s`);
-    output = [`${CSI}0J`, cursorTo(0), part1, "\n", part2].join("");
+    output = [`${CSI}2J`, cursorTo(0, 0), part1, "\n", part2].join("");
     await write(output);
-    // await write(`${CSI}u`);
-    await write(`${ESC}8`);
-
-    // clean only single line
-    // (TODO: this doesn't work when prompt becomes more than one line)
-    // output = [`${CSI}0J`, `${CSI}2K`, cursorTo(0), part1, `${ESC}7`].join("");
-    // await write(output);
-    // output = ["\n", part2, `${ESC}8`].join("");
-    // await write(output);
 
     // TODO: keep track of last output and clear only previously rendered lines
     // (this is what prompts, clack, etc.. does)
     // process.stdout.columns;
-
-    first = false;
   }
 
   const dispose = setupKeypressHandler(async (str: string, key: KeyInfo) => {
@@ -105,10 +79,6 @@ export async function promptAutocomplete(config: {
   });
 
   try {
-    // await write(`${CSI}1J`);
-    await write(`${CSI}2J`);
-    // await write(`${CSI}2S`);
-
     // await write(`${CSI}?25l`); // hide cursor
     render();
     return await manual.promise;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -440,6 +440,12 @@ importers:
         specifier: ^20.5.6
         version: 20.5.6
 
+  packages/utils-node/examples/basic:
+    dependencies:
+      '@hiogawa/utils-node':
+        specifier: latest
+        version: link:../..
+
   packages/utils-react:
     devDependencies:
       '@hiogawa/utils':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,3 +4,4 @@ packages:
   - packages/tiny-react/examples/*
   - packages/theme-script/examples/*
   - packages/tiny-refresh/examples/*
+  - packages/utils-node/examples/*


### PR DESCRIPTION
A little exercise to use `readline` and get familiar with CSI codes.

## todo

- [x] try `clack`'s input tracking? https://github.com/natemoo-re/clack/blob/67668ca0add8f234a49406e8ad60622ec12af987/packages/core/src/prompts/prompt.ts#L75
  - this feels so nice https://github.com/hi-ogawa/js-utils/pull/193/commits/f0752b315f512cf3656dc1ce29daccf62ae7a308
- [x] test
- [x] dog-food to `misc/pre-release.mjs`
- [x] demo on stackblitz
  - https://stackblitz.com/github/hi-ogawa/js-utils/tree/feat-prompt-autocomplete/packages/utils-node/examples/basic?file=index.mjs
