### PR TITLE
refactor(utils-node/prompt): expose readline instance

### DIFF
--- a/.changeset/gentle-buckets-whisper.md
+++ b/.changeset/gentle-buckets-whisper.md
@@ -1,0 +1,5 @@
+---
+"@hiogawa/utils-node": patch
+---
+
+Fix count showing "[1/0]" when empty

--- a/packages/utils-node/package.json
+++ b/packages/utils-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/utils-node",
-  "version": "0.0.1-pre.10",
+  "version": "0.0.1-pre.11",
   "homepage": "https://github.com/hi-ogawa/js-utils/tree/main/packages/utils-node",
   "repository": {
     "type": "git",

--- a/packages/utils-node/src/fixtures/prompt-debug.ts
+++ b/packages/utils-node/src/fixtures/prompt-debug.ts
@@ -14,8 +14,8 @@ quick debugging of keypress event
 
 async function main() {
   const manual = createManualPromise<void>();
-  const dispose = subscribePromptEvent((e) => {
-    console.log(JSON.stringify(e));
+  const { rl, dispose } = subscribePromptEvent((e) => {
+    console.log([rl.line, rl.cursor], JSON.stringify(e));
     if (e.type === "keypress") {
       const special = getSpecialKey(e.data);
       if (e.data.input === "q" || special === "abort") {

--- a/packages/utils-node/src/fixtures/prompt-debug.ts
+++ b/packages/utils-node/src/fixtures/prompt-debug.ts
@@ -16,16 +16,11 @@ async function main() {
   const manual = createManualPromise<void>();
   const { rl, dispose } = subscribePromptEvent((e) => {
     console.log([rl.line, rl.cursor], JSON.stringify(e));
-    if (e.type === "keypress") {
-      const special = getSpecialKey(e.data);
-      if (e.data.input === "q" || special === "abort") {
-        manual.resolve();
-      }
+    if (e.input === "q" || getSpecialKey(e) === "abort") {
+      manual.resolve();
+      return;
     }
-    if (e.type === "input") {
-      console.log(e.data);
-      console.log(colors.dim("> ") + formatInputCursor(e.data));
-    }
+    console.log(colors.dim("> ") + formatInputCursor(rl));
   });
   console.log(":: echo keypress event ('q' to quit)");
   try {

--- a/packages/utils-node/src/fixtures/prompt-debug.ts
+++ b/packages/utils-node/src/fixtures/prompt-debug.ts
@@ -2,7 +2,7 @@ import { colors, createManualPromise } from "@hiogawa/utils";
 import {
   formatInputCursor,
   getSpecialKey,
-  subscribePromptEvent,
+  subscribeReadlineEvent,
 } from "../prompt-utils";
 
 /*
@@ -14,7 +14,7 @@ quick debugging of keypress event
 
 async function main() {
   const manual = createManualPromise<void>();
-  const { rl, dispose } = subscribePromptEvent((e) => {
+  const { rl, dispose } = subscribeReadlineEvent((e) => {
     console.log([rl.line, rl.cursor], JSON.stringify(e));
     if (e.input === "q" || getSpecialKey(e) === "abort") {
       manual.resolve();

--- a/packages/utils-node/src/prompt-utils.ts
+++ b/packages/utils-node/src/prompt-utils.ts
@@ -73,10 +73,7 @@ const SPECIAL_KEYS = [
 export function getSpecialKey({
   input,
   key,
-}: PromptEventMap["keypress"]):
-  | (typeof SPECIAL_KEYS)[number]
-  | "abort"
-  | undefined {
+}: ReadlineKeypressEvent): (typeof SPECIAL_KEYS)[number] | "abort" | undefined {
   // ctrl-c ctrl-z
   if (input === "\x03" || input === "\x1A") {
     return "abort";
@@ -95,29 +92,14 @@ export interface KeyInfo {
   shift: boolean;
 }
 
-export interface PromptEventMap {
-  keypress: {
-    input?: string;
-    key: KeyInfo;
-  };
-  input: {
-    input: string;
-    cursor: number;
-  };
+export interface ReadlineKeypressEvent {
+  input?: string;
+  key: KeyInfo;
 }
 
-export type PromptEvent =
-  | {
-      type: "keypress";
-      data: PromptEventMap["keypress"];
-    }
-  | {
-      type: "input";
-      data: PromptEventMap["input"];
-    };
-
-// TODO: rename to setupReadlineKeypress
-export function subscribePromptEvent(handler: (e: PromptEvent) => void) {
+export function subscribePromptEvent(
+  handler: (e: ReadlineKeypressEvent) => void
+) {
   // cf.
   // https://github.com/natemoo-re/clack/blob/90f8e3d762e96fde614fdf8da0529866649fafe2/packages/core/src/prompts/prompt.ts#L93
   // https://github.com/terkelg/prompts/blob/735603af7c7990ac9efcfba6146967a7dbb15f50/lib/elements/prompt.js#L22-L23
@@ -145,11 +127,8 @@ export function subscribePromptEvent(handler: (e: PromptEvent) => void) {
 
   function onKeypress(input: string | undefined, key: KeyInfo) {
     handler({
-      type: "keypress",
-      data: {
-        input,
-        key,
-      },
+      input,
+      key,
     });
   }
   stdin.on("keypress", onKeypress);
@@ -166,12 +145,18 @@ export function subscribePromptEvent(handler: (e: PromptEvent) => void) {
   return { rl, dispose };
 }
 
-export function formatInputCursor({ input, cursor }: PromptEventMap["input"]) {
-  if (cursor >= input.length) {
-    input += " ".repeat(input.length - cursor + 1);
+export function formatInputCursor({
+  line,
+  cursor,
+}: {
+  line: string;
+  cursor: number;
+}) {
+  if (cursor >= line.length) {
+    line += " ".repeat(line.length - cursor + 1);
   }
-  const p1 = input.slice(0, cursor);
-  const p2 = input.slice(cursor, cursor + 1);
-  const p3 = input.slice(cursor + 1);
+  const p1 = line.slice(0, cursor);
+  const p2 = line.slice(cursor, cursor + 1);
+  const p3 = line.slice(cursor + 1);
   return p1 + colors.inverse(p2) + p3;
 }

--- a/packages/utils-node/src/prompt-utils.ts
+++ b/packages/utils-node/src/prompt-utils.ts
@@ -73,7 +73,7 @@ const SPECIAL_KEYS = [
 export function getSpecialKey({
   input,
   key,
-}: ReadlineKeypressEvent): (typeof SPECIAL_KEYS)[number] | "abort" | undefined {
+}: ReadlineEvent): (typeof SPECIAL_KEYS)[number] | "abort" | undefined {
   // ctrl-c ctrl-z
   if (input === "\x03" || input === "\x1A") {
     return "abort";
@@ -92,14 +92,12 @@ export interface KeyInfo {
   shift: boolean;
 }
 
-export interface ReadlineKeypressEvent {
+export interface ReadlineEvent {
   input?: string;
   key: KeyInfo;
 }
 
-export function subscribePromptEvent(
-  handler: (e: ReadlineKeypressEvent) => void
-) {
+export function subscribeReadlineEvent(handler: (e: ReadlineEvent) => void) {
   // cf.
   // https://github.com/natemoo-re/clack/blob/90f8e3d762e96fde614fdf8da0529866649fafe2/packages/core/src/prompts/prompt.ts#L93
   // https://github.com/terkelg/prompts/blob/735603af7c7990ac9efcfba6146967a7dbb15f50/lib/elements/prompt.js#L22-L23

--- a/packages/utils-node/src/prompt-utils.ts
+++ b/packages/utils-node/src/prompt-utils.ts
@@ -105,7 +105,7 @@ export function subscribePromptEvent(
   // https://github.com/terkelg/prompts/blob/735603af7c7990ac9efcfba6146967a7dbb15f50/lib/elements/prompt.js#L22-L23
 
   // setup dummy output stream to keep track of readline.line/cursor
-  const writeable = new Writable({
+  const writable = new Writable({
     highWaterMark: 0,
     write: (_chunk, _encoding, callback) => {
       callback();
@@ -115,7 +115,7 @@ export function subscribePromptEvent(
   const stdin = process.stdin;
   const rl = readline.createInterface({
     input: stdin,
-    output: writeable,
+    output: writable,
     terminal: true,
   });
   readline.emitKeypressEvents(stdin, rl);
@@ -139,7 +139,7 @@ export function subscribePromptEvent(
       stdin.setRawMode(previousRawMode);
     }
     rl.close();
-    writeable.destroy();
+    writable.destroy();
   }
 
   return { rl, dispose };

--- a/packages/utils-node/src/prompt.ts
+++ b/packages/utils-node/src/prompt.ts
@@ -6,7 +6,7 @@ import {
   computeHeight,
   formatInputCursor,
   getSpecialKey,
-  subscribePromptEvent,
+  subscribeReadlineEvent,
 } from "./prompt-utils";
 
 // cf. https://github.com/google/zx/blob/956dcc3bbdd349ac4c41f8db51add4efa2f58456/src/goods.ts#L83
@@ -103,7 +103,7 @@ export async function promptAutocomplete(options: {
   }
 
   // TODO: async handler race condition
-  const { rl, dispose } = subscribePromptEvent(async (e) => {
+  const { rl, dispose } = subscribeReadlineEvent(async (e) => {
     switch (getSpecialKey(e)) {
       case "abort":
       case "escape": {


### PR DESCRIPTION
While looking at Inquirer.js https://github.com/SBoudrias/Inquirer.js/blob/244e9e8d1119a06ac8d6884424cd345d150ae906/packages/input/src/index.mts#L60, I realized we can just expose readline instance to access line/cursor.