### PR TITLE
feat(tiny-rpc): support transferable

### DIFF
--- a/packages/tiny-rpc/package.json
+++ b/packages/tiny-rpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/tiny-rpc",
-  "version": "0.2.3-pre.12",
+  "version": "0.2.3-pre.13",
   "homepage": "https://github.com/hi-ogawa/js-utils/tree/main/packages/tiny-rpc",
   "repository": {
     "type": "git",

--- a/packages/tiny-rpc/package.json
+++ b/packages/tiny-rpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/tiny-rpc",
-  "version": "0.2.3-pre.11",
+  "version": "0.2.3-pre.12",
   "homepage": "https://github.com/hi-ogawa/js-utils/tree/main/packages/tiny-rpc",
   "repository": {
     "type": "git",

--- a/packages/tiny-rpc/src/adapter-message-port-node.ts
+++ b/packages/tiny-rpc/src/adapter-message-port-node.ts
@@ -15,7 +15,9 @@ export function messagePortNodeCompat(
   const map = new WeakMap();
 
   return {
-    postMessage(data) {
+    postMessage(data, options) {
+      // TODO
+      options?.transfer;
       port.postMessage(data);
     },
 

--- a/packages/tiny-rpc/src/adapter-message-port-node.ts
+++ b/packages/tiny-rpc/src/adapter-message-port-node.ts
@@ -2,7 +2,7 @@ import { tinyassert } from "@hiogawa/utils";
 import type { TinyRpcMessagePort } from "./adapter-message-port";
 
 export interface TinyRpcMessagePortNode {
-  postMessage(data: unknown): void;
+  postMessage(data: unknown, transferList?: ReadonlyArray<unknown>): void;
   on(type: "message", handler: NodeMessageHandler): void;
   off(type: "message", handler: NodeMessageHandler): void;
 }
@@ -16,9 +16,7 @@ export function messagePortNodeCompat(
 
   return {
     postMessage(data, options) {
-      // TODO
-      options?.transfer;
-      port.postMessage(data);
+      port.postMessage(data, options?.transfer);
     },
 
     addEventListener(type, handler) {

--- a/packages/tiny-rpc/src/adapter-message-port.test.ts
+++ b/packages/tiny-rpc/src/adapter-message-port.test.ts
@@ -4,7 +4,7 @@ import {
   type TinyRpcMessagePort,
   messagePortClientAdapter,
   messagePortServerAdapter,
-  wrapTransfer,
+  messagePortWrapTransfer,
 } from "./adapter-message-port";
 import type { TinyRpcMessagePortNode } from "./adapter-message-port-node";
 import { TinyRpcError, exposeTinyRpc, proxyTinyRpc } from "./core";
@@ -105,7 +105,7 @@ describe("adapter-message-port", () => {
       testResponse: (enable: boolean) => {
         const data = new Uint8Array([100]);
         if (enable) {
-          return wrapTransfer(data, [data.buffer]);
+          return messagePortWrapTransfer(data, [data.buffer]);
         }
         return data;
       },
@@ -127,7 +127,7 @@ describe("adapter-message-port", () => {
       const data = new Uint8Array([100]);
       expect(data.byteLength).toMatchInlineSnapshot(`1`);
       expect(
-        await client.testRequest(wrapTransfer(data, [data.buffer]))
+        await client.testRequest(messagePortWrapTransfer(data, [data.buffer]))
       ).toMatchInlineSnapshot(`100`);
       expect(data.byteLength).toMatchInlineSnapshot(`0`);
     }

--- a/packages/tiny-rpc/src/adapter-message-port.ts
+++ b/packages/tiny-rpc/src/adapter-message-port.ts
@@ -142,7 +142,10 @@ class WrapepdTransfer {
   constructor(public inner: [unknown, unknown[]]) {}
 }
 
-export function wrapTransfer<T>(value: T, transferables: unknown[]): T {
+export function messagePortWrapTransfer<T>(
+  value: T,
+  transferables: unknown[]
+): T {
   return new WrapepdTransfer([value, transferables]) as any;
 }
 

--- a/packages/tiny-rpc/src/adapter-message-port.ts
+++ b/packages/tiny-rpc/src/adapter-message-port.ts
@@ -1,6 +1,7 @@
 import {
   type Result,
   createManualPromise,
+  uniq,
   wrapErrorAsync,
 } from "@hiogawa/utils";
 import {
@@ -11,7 +12,6 @@ import {
 } from "./core";
 
 // TODO:
-// - support "transferable"?
 // - dispose?
 
 //
@@ -20,10 +20,15 @@ import {
 //
 
 export interface TinyRpcMessagePort {
-  postMessage(data: unknown): void;
+  postMessage(data: unknown, options?: postMessageOptions): void;
   addEventListener(type: "message", handler: MessageHandler): void;
   removeEventListener(type: "message", handler: MessageHandler): void;
 }
+
+// cf. StructuredSerializeOptions
+type postMessageOptions = {
+  transfer?: unknown[];
+};
 
 type MessageHandler = (ev: { data: unknown }) => void;
 
@@ -44,7 +49,12 @@ export function messagePortServerAdapter({
       return listen(port, async (ev) => {
         // TODO: collision check req.id on server?
         const req = ev.data as RequestPayload;
-        const result = await wrapErrorAsync(async () => invokeRoute(req.data));
+        let transfer!: unknown[];
+        const result = await wrapErrorAsync(async () => {
+          let ret = await invokeRoute(req.data);
+          [ret, transfer] = unwrapTransfer(ret);
+          return ret;
+        });
         if (!result.ok) {
           onError?.(result.value);
           result.value = TinyRpcError.fromUnknown(result.value).serialize();
@@ -53,7 +63,7 @@ export function messagePortServerAdapter({
           id: req.id,
           result,
         };
-        port.postMessage(res);
+        port.postMessage(res, { transfer });
       });
     },
   };
@@ -68,9 +78,12 @@ export function messagePortClientAdapter({
 }): TinyRpcClientAdapter {
   return {
     send: async (data) => {
+      const unwraped = data.args.map((arg) => unwrapTransfer(arg));
+      const args = unwraped.map(([arg]) => arg);
+      const transfer = uniq(unwraped.flatMap(([_, t]) => t));
       const req: RequestPayload = {
         id: generateId(),
-        data,
+        data: { ...data, args },
       };
       const responsePromise = createManualPromise<ResponsePayload>();
       const unlisten = listen(port, (ev) => {
@@ -80,7 +93,7 @@ export function messagePortClientAdapter({
           unlisten();
         }
       });
-      port.postMessage(req);
+      port.postMessage(req, { transfer });
       const res = await responsePromise;
       if (!res.result.ok) {
         throw TinyRpcError.deserialize(res.result.value);
@@ -123,4 +136,19 @@ function listen(port: TinyRpcMessagePort, listener: MessageHandler) {
   return () => {
     port.removeEventListener("message", listener);
   };
+}
+
+class WrapepdTransfer {
+  constructor(public inner: [unknown, unknown[]]) {}
+}
+
+export function wrapTransfer<T>(value: T, transferables: unknown[]): T {
+  return new WrapepdTransfer([value, transferables]) as any;
+}
+
+function unwrapTransfer(value: unknown): [unknown, unknown[]] {
+  if (value instanceof WrapepdTransfer) {
+    return value.inner;
+  }
+  return [value, []];
 }


### PR DESCRIPTION
Doing something similar to `Comlink.transfer` https://github.com/GoogleChromeLabs/comlink?tab=readme-ov-file#comlinktransfervalue-transferables-and-comlinkproxyvalue