### PR TITLE
ci: update node to fix tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,14 +3,14 @@ on:
   push:
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
       - run: corepack enable
-      - run: pnpm i --frozen-lockfile
+      - run: pnpm i
       - run: pnpm lint-check
       - run: pnpm build
       - run: pnpm tsc

--- a/packages/cpgh/src/cli.test.ts
+++ b/packages/cpgh/src/cli.test.ts
@@ -1,7 +1,7 @@
 import { $ } from "@hiogawa/utils-node";
 import { expect, it } from "vitest";
 
-it("basic", async () => {
+it("basic", { timeout: 60_000 }, async () => {
   await $`pnpm cli --force https://github.com/vitest-dev/vitest/tree/main/examples/basic /tmp/my-project`;
   const output = await $`ls /tmp/my-project`;
   expect(output.split(/\s/).sort()).toMatchInlineSnapshot(`


### PR DESCRIPTION
It looks like CI started to fail. Maybe related to node version with `import.meta.resolve`?
- https://github.com/hi-ogawa/js-utils/actions/runs/8623638543/job/23637191892#step:9:213