### PR TITLE
feat(node): add `generateParseArgsHelp`

### DIFF
--- a/packages/utils-node/src/parse-args.test.ts
+++ b/packages/utils-node/src/parse-args.test.ts
@@ -55,7 +55,6 @@ describe(generateParseArgsHelp, () => {
       {
         "positionals": [],
         "values": {
-          "dir": "/home/hiroshi/code/personal/js-utils/packages/utils-node",
           "help": true,
           "to": "HEAD",
         },

--- a/packages/utils-node/src/parse-args.test.ts
+++ b/packages/utils-node/src/parse-args.test.ts
@@ -19,7 +19,6 @@ describe(generateParseArgsHelp, () => {
         },
         dir: {
           type: "string",
-          default: process.cwd(),
           $help: "(default: process.cwd())",
         },
         dry: {

--- a/packages/utils-node/src/parse-args.test.ts
+++ b/packages/utils-node/src/parse-args.test.ts
@@ -1,0 +1,66 @@
+import { parseArgs } from "util";
+import { describe, expect, it } from "vitest";
+import { type ParseArgsConfigExtra, generateParseArgsHelp } from "./parse-args";
+
+describe(generateParseArgsHelp, () => {
+  it("basic", () => {
+    const config = {
+      $program: "changelog",
+      $version: "0.0.0",
+      options: {
+        from: {
+          type: "string",
+          $help: "(default: last commit modified CHANGELOG.md)",
+        },
+        to: {
+          type: "string",
+          default: "HEAD",
+          $help: "(default: HEAD)",
+        },
+        dir: {
+          type: "string",
+          default: process.cwd(),
+          $help: "(default: process.cwd())",
+        },
+        dry: {
+          type: "boolean",
+        },
+        help: {
+          type: "boolean",
+          short: "h",
+        },
+      },
+    } satisfies ParseArgsConfigExtra;
+
+    expect(generateParseArgsHelp(config)).toMatchInlineSnapshot(`
+      "changelog/0.0.0
+
+      Usage:
+        $ changelog [options]
+
+      Options:
+        --from=...    (default: last commit modified CHANGELOG.md)
+        --to=...      (default: HEAD)
+        --dir=...     (default: process.cwd())
+        --dry
+        --help, -h
+
+      "
+    `);
+
+    const args = parseArgs({
+      args: ["-h"],
+      ...config,
+    });
+    expect(args).toMatchInlineSnapshot(`
+      {
+        "positionals": [],
+        "values": {
+          "dir": "/home/hiroshi/code/personal/js-utils/packages/utils-node",
+          "help": true,
+          "to": "HEAD",
+        },
+      }
+    `);
+  });
+});

--- a/packages/utils-node/src/parse-args.ts
+++ b/packages/utils-node/src/parse-args.ts
@@ -1,0 +1,71 @@
+import type { ParseArgsConfig } from "node:util";
+import { range } from "@hiogawa/utils";
+
+// TOOD: positional?
+
+export interface ParseArgsConfigExtra extends ParseArgsConfig {
+  $program?: string;
+  $version?: string;
+  $description?: string;
+  options?: {
+    [longOption: string]: ParseArgsOptionConfig & {
+      $help?: string;
+    };
+  };
+}
+
+// not exported
+type ParseArgsOptionConfig = NonNullable<ParseArgsConfig["options"]>[string];
+
+export function generateParseArgsHelp(config: ParseArgsConfigExtra) {
+  const { $program = "my-cli", $version, $description } = config;
+  let output = `\
+${[$program, $version].filter(Boolean).join("/")}
+
+Usage:
+  $ ${$program} [options]
+
+`;
+  if ($description) {
+    output += $description + "\n\n";
+  }
+  if (config.options) {
+    const entries = Object.entries(config.options);
+    const table = entries.map(([k, v]) => [
+      `--${k}` +
+        (v.short ? `, -${v.short}` : "") +
+        (v.type === "string" ? "=..." : ""),
+      "$help" in v ? String(v.$help) : "",
+    ]);
+    const tableOutput = formatIndent(
+      padColumns(table).map((row) => row.join(" ".repeat(4)).trimEnd()),
+      2
+    );
+    output += `\
+Options:
+${tableOutput}
+
+`;
+  }
+  return output;
+}
+
+// copied from
+// https://github.com/hi-ogawa/js-utils/blob/9acdc281f344a92fca242ffadf791427f726b564/packages/tiny-cli/src/utils.ts#L15
+function padColumns(rows: string[][]): string[][] {
+  if (rows.length === 0) {
+    return rows;
+  }
+  const ncol = Math.max(...rows.map((row) => row.length));
+  const widths = range(ncol).map((c) =>
+    Math.max(...rows.map((row) => row[c]?.length ?? 0))
+  );
+  const newRows = rows.map((row) =>
+    row.map((v, i) => v.padEnd(widths[i], " "))
+  );
+  return newRows;
+}
+
+function formatIndent(ls: string[], n: number): string {
+  return ls.map((v) => " ".repeat(n) + v).join("\n");
+}


### PR DESCRIPTION
Sometimes `tiny-cli` feels overkill, so thinking a way to utilize `parseArgs` from `node:util`.

For starter, this will be used for:
- https://github.com/hi-ogawa/js-utils/pull/225