### PR TITLE
fix(tiny-react): use symbol for node type

### DIFF
--- a/packages/tiny-react/examples/server/src/entry-browser.tsx
+++ b/packages/tiny-react/examples/server/src/entry-browser.tsx
@@ -9,6 +9,7 @@ import {
 } from "@hiogawa/tiny-react";
 import { tinyassert } from "@hiogawa/utils";
 import { createReferenceMap } from "./integration/client-reference/runtime";
+import { jsonUnescapeSymbol } from "./integration/serialization";
 
 async function main() {
   if (window.location.href.includes("__nojs")) {
@@ -25,7 +26,7 @@ async function main() {
         url.searchParams.set("__serialize", "");
         const res = await fetch(url);
         tinyassert(res.ok);
-        const result: SerializeResult = await res.json();
+        const result: SerializeResult = jsonUnescapeSymbol(await res.text());
         const newVnode = deserialize<VNode>(
           result.data,
           await createReferenceMap(result.referenceIds)
@@ -38,7 +39,9 @@ async function main() {
   }
 
   // hydrate with initial SNode
-  const initResult: SerializeResult = (globalThis as any).__serialized;
+  const initResult: SerializeResult = jsonUnescapeSymbol(
+    (globalThis as any).__serialized
+  );
   const vnode = deserialize<VNode>(
     initResult.data,
     await createReferenceMap(initResult.referenceIds)

--- a/packages/tiny-react/examples/server/src/entry-server.tsx
+++ b/packages/tiny-react/examples/server/src/entry-server.tsx
@@ -6,6 +6,7 @@ import {
 } from "@hiogawa/tiny-react";
 import type { ViteDevServer } from "vite";
 import { createReferenceMap } from "./integration/client-reference/runtime";
+import { jsonEscapeSymbol } from "./integration/serialization";
 import Layout from "./routes/layout";
 
 export async function handler(request: Request) {
@@ -15,7 +16,7 @@ export async function handler(request: Request) {
 
   // to CSR
   if (url.searchParams.has("__serialize")) {
-    return new Response(JSON.stringify(serialized), {
+    return new Response(jsonEscapeSymbol(serialized), {
       headers: {
         "content-type": "application/json",
       },
@@ -35,7 +36,7 @@ export async function handler(request: Request) {
     "<head>",
     () =>
       `<head><script>globalThis.__serialized = ${JSON.stringify(
-        serialized
+        jsonEscapeSymbol(serialized)
       )}</script>`
   );
   // dev only FOUC fix

--- a/packages/tiny-react/examples/server/src/integration/serialization.ts
+++ b/packages/tiny-react/examples/server/src/integration/serialization.ts
@@ -15,7 +15,7 @@ export function jsonEscapeSymbol(v: unknown) {
 export function jsonUnescapeSymbol(s: string) {
   return JSON.parse(s, function (_k, v) {
     if (typeof v === "string" && v.startsWith("!s:")) {
-      return Symbol.for(s.slice(3));
+      return Symbol.for(v.slice(3));
     }
     if (typeof v === "string" && v.startsWith("!")) {
       return v.slice(1);

--- a/packages/tiny-react/examples/server/src/integration/serialization.ts
+++ b/packages/tiny-react/examples/server/src/integration/serialization.ts
@@ -1,0 +1,25 @@
+export function jsonEscapeSymbol(v: unknown) {
+  return JSON.stringify(v, function (_k, v) {
+    // escape collision
+    if (typeof v === "string" && v.startsWith("!")) {
+      return "!" + v;
+    }
+    // symbol
+    if (typeof v === "symbol" && typeof v.description === "string") {
+      return "!s:" + v.description;
+    }
+    return v;
+  });
+}
+
+export function jsonUnescapeSymbol(s: string) {
+  return JSON.parse(s, function (_k, v) {
+    if (typeof v === "string" && v.startsWith("!s:")) {
+      return Symbol.for(s.slice(3));
+    }
+    if (typeof v === "string" && v.startsWith("!")) {
+      return v.slice(1);
+    }
+    return v;
+  });
+}

--- a/packages/tiny-react/src/helper/hyperscript.test.tsx
+++ b/packages/tiny-react/src/helper/hyperscript.test.tsx
@@ -34,7 +34,7 @@ describe("hyperscript", () => {
                 "value": "hello",
               },
               "render": [Function],
-              "type": "custom",
+              "type": Symbol(tiny-react.custom),
             },
             null,
             0,
@@ -42,7 +42,7 @@ describe("hyperscript", () => {
               "key": undefined,
               "props": {},
               "render": [Function],
-              "type": "custom",
+              "type": Symbol(tiny-react.custom),
             },
             undefined,
             {
@@ -53,7 +53,7 @@ describe("hyperscript", () => {
                 "className": "text-red",
                 "ref": [Function],
               },
-              "type": "tag",
+              "type": Symbol(tiny-react.tag),
             },
             {
               "key": undefined,
@@ -61,7 +61,7 @@ describe("hyperscript", () => {
               "props": {
                 "children": 0,
               },
-              "type": "tag",
+              "type": Symbol(tiny-react.tag),
             },
             {
               "key": undefined,
@@ -72,7 +72,7 @@ describe("hyperscript", () => {
                   1,
                 ],
               },
-              "type": "tag",
+              "type": Symbol(tiny-react.tag),
             },
             {
               "key": undefined,
@@ -82,7 +82,7 @@ describe("hyperscript", () => {
                   0,
                 ],
               },
-              "type": "tag",
+              "type": Symbol(tiny-react.tag),
             },
             {
               "key": undefined,
@@ -93,12 +93,12 @@ describe("hyperscript", () => {
                   1,
                 ],
               },
-              "type": "tag",
+              "type": Symbol(tiny-react.tag),
             },
           ],
           "className": "flex",
         },
-        "type": "tag",
+        "type": Symbol(tiny-react.tag),
       }
     `);
   });
@@ -109,7 +109,7 @@ describe("hyperscript", () => {
         "key": undefined,
         "props": {},
         "render": [Function],
-        "type": "custom",
+        "type": Symbol(tiny-react.custom),
       }
     `);
     expect(h(Fragment, {}, 1)).toMatchInlineSnapshot(`
@@ -119,7 +119,7 @@ describe("hyperscript", () => {
           "children": 1,
         },
         "render": [Function],
-        "type": "custom",
+        "type": Symbol(tiny-react.custom),
       }
     `);
     expect(h(Fragment, { children: 1 })).toMatchInlineSnapshot(`
@@ -129,7 +129,7 @@ describe("hyperscript", () => {
           "children": 1,
         },
         "render": [Function],
-        "type": "custom",
+        "type": Symbol(tiny-react.custom),
       }
     `);
     expect(h(Fragment, { children: [1] })).toMatchInlineSnapshot(`
@@ -141,7 +141,7 @@ describe("hyperscript", () => {
           ],
         },
         "render": [Function],
-        "type": "custom",
+        "type": Symbol(tiny-react.custom),
       }
     `);
     expect(h(Fragment, { children: 1 }, 2)).toMatchInlineSnapshot(`
@@ -151,7 +151,7 @@ describe("hyperscript", () => {
           "children": 2,
         },
         "render": [Function],
-        "type": "custom",
+        "type": Symbol(tiny-react.custom),
       }
     `);
   });

--- a/packages/tiny-react/src/helper/jsx-runtime.test.tsx
+++ b/packages/tiny-react/src/helper/jsx-runtime.test.tsx
@@ -22,7 +22,7 @@ test("basic", () => {
               "children": "yay",
               "className": "hehe",
             },
-            "type": "tag",
+            "type": Symbol(tiny-react.tag),
           },
           {
             "key": undefined,
@@ -35,17 +35,17 @@ test("basic", () => {
                   "props": {
                     "children": "ment",
                   },
-                  "type": "tag",
+                  "type": Symbol(tiny-react.tag),
                 },
               ],
             },
             "render": [Function],
-            "type": "custom",
+            "type": Symbol(tiny-react.custom),
           },
         ],
         "id": "hi",
       },
-      "type": "tag",
+      "type": Symbol(tiny-react.tag),
     }
   `);
 });

--- a/packages/tiny-react/src/index.test.tsx
+++ b/packages/tiny-react/src/index.test.tsx
@@ -49,19 +49,19 @@ describe(render, () => {
           "children": [
             {
               "hnode": hello,
-              "type": "text",
+              "type": Symbol(tiny-react.text),
               "vnode": {
                 "data": "hello",
-                "type": "text",
+                "type": Symbol(tiny-react.text),
               },
             },
             {
               "child": {
                 "hnode": world,
-                "type": "text",
+                "type": Symbol(tiny-react.text),
                 "vnode": {
                   "data": "world",
-                  "type": "text",
+                  "type": Symbol(tiny-react.text),
                 },
               },
               "hnode": <span
@@ -70,7 +70,7 @@ describe(render, () => {
                 world
               </span>,
               "listeners": Map {},
-              "type": "tag",
+              "type": Symbol(tiny-react.tag),
               "vnode": {
                 "key": undefined,
                 "name": "span",
@@ -78,7 +78,7 @@ describe(render, () => {
                   "children": "world",
                   "className": "text-red",
                 },
-                "type": "tag",
+                "type": Symbol(tiny-react.tag),
               },
             },
           ],
@@ -88,12 +88,12 @@ describe(render, () => {
           >
             world
           </span>,
-          "type": "fragment",
+          "type": Symbol(tiny-react.fragment),
           "vnode": {
             "children": [
               {
                 "data": "hello",
-                "type": "text",
+                "type": Symbol(tiny-react.text),
               },
               {
                 "key": undefined,
@@ -102,10 +102,10 @@ describe(render, () => {
                   "children": "world",
                   "className": "text-red",
                 },
-                "type": "tag",
+                "type": Symbol(tiny-react.tag),
               },
             ],
-            "type": "fragment",
+            "type": Symbol(tiny-react.fragment),
           },
         },
         "hnode": <div
@@ -119,7 +119,7 @@ describe(render, () => {
           </span>
         </div>,
         "listeners": Map {},
-        "type": "tag",
+        "type": Symbol(tiny-react.tag),
         "vnode": {
           "key": undefined,
           "name": "div",
@@ -133,12 +133,12 @@ describe(render, () => {
                   "children": "world",
                   "className": "text-red",
                 },
-                "type": "tag",
+                "type": Symbol(tiny-react.tag),
               },
             ],
             "className": "flex items-center gap-2",
           },
-          "type": "tag",
+          "type": Symbol(tiny-react.tag),
         },
       }
     `);
@@ -157,10 +157,10 @@ describe(render, () => {
       {
         "child": {
           "hnode": reconcile,
-          "type": "text",
+          "type": Symbol(tiny-react.text),
           "vnode": {
             "data": "reconcile",
-            "type": "text",
+            "type": Symbol(tiny-react.text),
           },
         },
         "hnode": <div
@@ -169,7 +169,7 @@ describe(render, () => {
           reconcile
         </div>,
         "listeners": Map {},
-        "type": "tag",
+        "type": Symbol(tiny-react.tag),
         "vnode": {
           "key": undefined,
           "name": "div",
@@ -177,7 +177,7 @@ describe(render, () => {
             "children": "reconcile",
             "className": "flex items-center gap-2",
           },
-          "type": "tag",
+          "type": Symbol(tiny-react.tag),
         },
       }
     `);
@@ -209,38 +209,38 @@ describe(render, () => {
               {
                 "child": {
                   "hnode": hello,
-                  "type": "text",
+                  "type": Symbol(tiny-react.text),
                   "vnode": {
                     "data": "hello",
-                    "type": "text",
+                    "type": Symbol(tiny-react.text),
                   },
                 },
                 "hnode": <span>
                   hello
                 </span>,
                 "listeners": Map {},
-                "type": "tag",
+                "type": Symbol(tiny-react.tag),
                 "vnode": {
                   "key": undefined,
                   "name": "span",
                   "props": {
                     "children": "hello",
                   },
-                  "type": "tag",
+                  "type": Symbol(tiny-react.tag),
                 },
               },
               {
                 "hnode": world,
-                "type": "text",
+                "type": Symbol(tiny-react.text),
                 "vnode": {
                   "data": "world",
-                  "type": "text",
+                  "type": Symbol(tiny-react.text),
                 },
               },
             ],
             "parent": [Circular],
             "slot": world,
-            "type": "fragment",
+            "type": Symbol(tiny-react.fragment),
             "vnode": {
               "children": [
                 {
@@ -249,14 +249,14 @@ describe(render, () => {
                   "props": {
                     "children": "hello",
                   },
-                  "type": "tag",
+                  "type": Symbol(tiny-react.tag),
                 },
                 {
                   "data": "world",
-                  "type": "text",
+                  "type": Symbol(tiny-react.text),
                 },
               ],
-              "type": "fragment",
+              "type": Symbol(tiny-react.fragment),
             },
           },
           "hnode": <div>
@@ -266,7 +266,7 @@ describe(render, () => {
             world
           </div>,
           "listeners": Map {},
-          "type": "tag",
+          "type": Symbol(tiny-react.tag),
           "vnode": {
             "key": undefined,
             "name": "div",
@@ -278,12 +278,12 @@ describe(render, () => {
                   "props": {
                     "children": "hello",
                   },
-                  "type": "tag",
+                  "type": Symbol(tiny-react.tag),
                 },
                 "world",
               ],
             },
-            "type": "tag",
+            "type": Symbol(tiny-react.tag),
           },
         },
         "hookContext": HookContext {
@@ -309,14 +309,14 @@ describe(render, () => {
           </span>
           world
         </div>,
-        "type": "custom",
+        "type": Symbol(tiny-react.custom),
         "vnode": {
           "key": undefined,
           "props": {
             "value": "hello",
           },
           "render": [Function],
-          "type": "custom",
+          "type": Symbol(tiny-react.custom),
         },
       }
     `);
@@ -1598,7 +1598,7 @@ describe("custom-children", () => {
                 "children": "hello",
               },
               "render": [Function],
-              "type": "custom",
+              "type": Symbol(tiny-react.custom),
             },
             {
               "key": "key2",
@@ -1606,11 +1606,11 @@ describe("custom-children", () => {
                 "children": "hello",
               },
               "render": [Function],
-              "type": "custom",
+              "type": Symbol(tiny-react.custom),
             },
           ],
         },
-        "type": "tag",
+        "type": Symbol(tiny-react.tag),
       }
     `);
     expect(parent).toMatchInlineSnapshot(`

--- a/packages/tiny-react/src/server/index.test.tsx
+++ b/packages/tiny-react/src/server/index.test.tsx
@@ -30,12 +30,12 @@ describe(serializeNode, () => {
                 "children": "world",
                 "title": "foo",
               },
-              "type": "tag",
+              "type": Symbol(tiny-react.tag),
             },
           ],
           "className": "flex",
         },
-        "type": "tag",
+        "type": Symbol(tiny-react.tag),
       }
     `);
 
@@ -55,12 +55,12 @@ describe(serializeNode, () => {
                 "children": "world",
                 "title": "foo",
               },
-              "type": "tag",
+              "type": Symbol(tiny-react.tag),
             },
           ],
           "className": "flex",
         },
-        "type": "tag",
+        "type": Symbol(tiny-react.tag),
       }
     `);
 
@@ -106,10 +106,10 @@ describe(serializeNode, () => {
             "props": {
               "children": "{"prop":123}",
             },
-            "type": "tag",
+            "type": Symbol(tiny-react.tag),
           },
         },
-        "type": "tag",
+        "type": Symbol(tiny-react.tag),
       }
     `);
 
@@ -125,10 +125,10 @@ describe(serializeNode, () => {
             "props": {
               "children": "{"prop":123}",
             },
-            "type": "tag",
+            "type": Symbol(tiny-react.tag),
           },
         },
-        "type": "tag",
+        "type": Symbol(tiny-react.tag),
       }
     `);
 
@@ -175,14 +175,14 @@ describe(serializeNode, () => {
                 "key": undefined,
                 "name": "span",
                 "props": {},
-                "type": "tag",
+                "type": Symbol(tiny-react.tag),
               },
             },
-            "type": "custom",
+            "type": Symbol(tiny-react.custom),
           },
           "id": "server",
         },
-        "type": "tag",
+        "type": Symbol(tiny-react.tag),
       }
     `);
 
@@ -199,15 +199,15 @@ describe(serializeNode, () => {
                 "key": undefined,
                 "name": "span",
                 "props": {},
-                "type": "tag",
+                "type": Symbol(tiny-react.tag),
               },
             },
             "render": [Function],
-            "type": "custom",
+            "type": Symbol(tiny-react.custom),
           },
           "id": "server",
         },
-        "type": "tag",
+        "type": Symbol(tiny-react.tag),
       }
     `);
 
@@ -272,17 +272,17 @@ describe(serializeNode, () => {
                     "key": undefined,
                     "name": "span",
                     "props": {},
-                    "type": "tag",
+                    "type": Symbol(tiny-react.tag),
                   },
                 },
-                "type": "custom",
+                "type": Symbol(tiny-react.custom),
               },
               "id": "server",
             },
-            "type": "tag",
+            "type": Symbol(tiny-react.tag),
           },
         },
-        "type": "custom",
+        "type": Symbol(tiny-react.custom),
       }
     `);
 
@@ -305,19 +305,19 @@ describe(serializeNode, () => {
                     "key": undefined,
                     "name": "span",
                     "props": {},
-                    "type": "tag",
+                    "type": Symbol(tiny-react.tag),
                   },
                 },
                 "render": [Function],
-                "type": "custom",
+                "type": Symbol(tiny-react.custom),
               },
               "id": "server",
             },
-            "type": "tag",
+            "type": Symbol(tiny-react.tag),
           },
         },
         "render": [Function],
-        "type": "custom",
+        "type": Symbol(tiny-react.custom),
       }
     `);
 
@@ -375,13 +375,13 @@ describe(serializeNode, () => {
                 "key": undefined,
                 "name": "span",
                 "props": {},
-                "type": "tag",
+                "type": Symbol(tiny-react.tag),
               },
             },
-            "type": "custom",
+            "type": Symbol(tiny-react.custom),
           },
         },
-        "type": "custom",
+        "type": Symbol(tiny-react.custom),
       }
     `);
 
@@ -400,15 +400,15 @@ describe(serializeNode, () => {
                 "key": undefined,
                 "name": "span",
                 "props": {},
-                "type": "tag",
+                "type": Symbol(tiny-react.tag),
               },
             },
             "render": [Function],
-            "type": "custom",
+            "type": Symbol(tiny-react.custom),
           },
         },
         "render": [Function],
-        "type": "custom",
+        "type": Symbol(tiny-react.custom),
       }
     `);
 

--- a/packages/tiny-react/src/server/index.test.tsx
+++ b/packages/tiny-react/src/server/index.test.tsx
@@ -434,4 +434,36 @@ describe(serializeNode, () => {
       serializeNode(<div onclick={() => {}} />)
     ).rejects.toMatchInlineSnapshot(`[Error: Cannot serialize function]`);
   });
+
+  it("no 'type' collision", async () => {
+    function Custom(_props: { x: { type: "tag" } }) {
+      return <></>;
+    }
+    registerClientReference(Custom, "#Custom");
+
+    const result = await serializeNode(
+      <Custom
+        x={{
+          type: "tag",
+        }}
+      />
+    );
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "referenceIds": [
+          "#Custom",
+        ],
+        "snode": {
+          "$$id": "#Custom",
+          "key": undefined,
+          "props": {
+            "x": {
+              "type": "tag",
+            },
+          },
+          "type": Symbol(tiny-react.custom),
+        },
+      }
+    `);
+  });
 });

--- a/packages/tiny-react/src/server/index.test.tsx
+++ b/packages/tiny-react/src/server/index.test.tsx
@@ -451,10 +451,7 @@ describe(serialize, () => {
     );
     expect(result).toMatchInlineSnapshot(`
       {
-        "referenceIds": [
-          "#Custom",
-        ],
-        "snode": {
+        "data": {
           "$$id": "#Custom",
           "key": undefined,
           "props": {
@@ -464,6 +461,9 @@ describe(serialize, () => {
           },
           "type": Symbol(tiny-react.custom),
         },
+        "referenceIds": [
+          "#Custom",
+        ],
       }
     `);
   });
@@ -520,14 +520,14 @@ describe(serialize, () => {
                   "props": {
                     "children": "hey",
                   },
-                  "type": "custom",
+                  "type": Symbol(tiny-react.custom),
                 },
               },
-              "type": "tag",
+              "type": Symbol(tiny-react.tag),
             },
             "id": "server",
           },
-          "type": "tag",
+          "type": Symbol(tiny-react.tag),
         },
         "k2": [
           {
@@ -544,14 +544,14 @@ describe(serialize, () => {
                     "props": {
                       "children": "yo",
                     },
-                    "type": "custom",
+                    "type": Symbol(tiny-react.custom),
                   },
                 },
-                "type": "tag",
+                "type": Symbol(tiny-react.tag),
               },
               "id": "server",
             },
-            "type": "tag",
+            "type": Symbol(tiny-react.tag),
           },
         ],
       }
@@ -577,14 +577,14 @@ describe(serialize, () => {
                     "children": "hey",
                   },
                   "render": [Function],
-                  "type": "custom",
+                  "type": Symbol(tiny-react.custom),
                 },
               },
-              "type": "tag",
+              "type": Symbol(tiny-react.tag),
             },
             "id": "server",
           },
-          "type": "tag",
+          "type": Symbol(tiny-react.tag),
         },
         "k2": [
           {
@@ -601,14 +601,14 @@ describe(serialize, () => {
                       "children": "yo",
                     },
                     "render": [Function],
-                    "type": "custom",
+                    "type": Symbol(tiny-react.custom),
                   },
                 },
-                "type": "tag",
+                "type": Symbol(tiny-react.tag),
               },
               "id": "server",
             },
-            "type": "tag",
+            "type": Symbol(tiny-react.tag),
           },
         ],
       }

--- a/packages/tiny-react/src/server/index.ts
+++ b/packages/tiny-react/src/server/index.ts
@@ -23,6 +23,8 @@ import {
 // serialize
 //
 
+// cf. https://react.dev/reference/rsc/use-client#serializable-types
+
 export type SerializeResult = {
   snode: SNode;
   referenceIds: string[];

--- a/packages/tiny-react/src/server/index.ts
+++ b/packages/tiny-react/src/server/index.ts
@@ -25,6 +25,11 @@ import {
 
 // cf. https://react.dev/reference/rsc/use-client#serializable-types
 
+// TOOD: we can probably use general framework to do RNode serialization such as
+// packages/json-extra
+// devalue
+// turbo-stream
+
 export type SerializeResult = {
   data: unknown;
   referenceIds: string[];

--- a/packages/tiny-react/src/ssr/index.test.tsx
+++ b/packages/tiny-react/src/ssr/index.test.tsx
@@ -173,7 +173,7 @@ describe(hydrate, () => {
         "props": {
           "children": "",
         },
-        "type": "tag",
+        "type": Symbol(tiny-react.tag),
       }
     `);
 
@@ -207,7 +207,7 @@ describe(hydrate, () => {
         "props": {
           "children": " ",
         },
-        "type": "tag",
+        "type": Symbol(tiny-react.tag),
       }
     `);
 
@@ -246,7 +246,7 @@ describe(hydrate, () => {
             "b",
           ],
         },
-        "type": "tag",
+        "type": Symbol(tiny-react.tag),
       }
     `);
 

--- a/packages/tiny-react/src/ssr/render.test.tsx
+++ b/packages/tiny-react/src/ssr/render.test.tsx
@@ -46,7 +46,7 @@ describe(renderToString, () => {
           ],
           "title": "a & b",
         },
-        "type": "tag",
+        "type": Symbol(tiny-react.tag),
       }
     `);
     expect(renderToString(vnode)).toMatchInlineSnapshot(

--- a/packages/tiny-react/src/virtual-dom.ts
+++ b/packages/tiny-react/src/virtual-dom.ts
@@ -13,12 +13,12 @@ export type HNode = Node;
 export type HTag = Element;
 export type HText = Text;
 
-// node type (TODO: check perf between string, number, symbol)
-export const NODE_TYPE_EMPTY = "empty" as const;
-export const NODE_TYPE_TAG = "tag" as const;
-export const NODE_TYPE_TEXT = "text" as const;
-export const NODE_TYPE_CUSTOM = "custom" as const;
-export const NODE_TYPE_FRAGMENT = "fragment" as const;
+// node type
+export const NODE_TYPE_EMPTY = Symbol.for("tiny-react.empty");
+export const NODE_TYPE_TAG = Symbol.for("tiny-react.tag");
+export const NODE_TYPE_TEXT = Symbol.for("tiny-react.text");
+export const NODE_TYPE_CUSTOM = Symbol.for("tiny-react.custom");
+export const NODE_TYPE_FRAGMENT = Symbol.for("tiny-react.fragment");
 
 export function isVNode(v: unknown): v is VNode {
   return (


### PR DESCRIPTION
## todo

- [x] reproduction of `{ type: ... }` collision
- [x] serialization/deserialization doesn't need to be RNode/SNode
  - https://github.com/hi-ogawa/js-utils/pull/244
- [ ] replace/revive symbol out-of-the-box?

---

Alternative would be to use `__v_isVNode: true` like vuejs?