### PR TITLE
feat(node): add `webToNodeHandler`

### DIFF
--- a/packages/utils-node/package.json
+++ b/packages/utils-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/utils-node",
-  "version": "0.0.1-pre.15",
+  "version": "0.0.1-pre.16",
   "homepage": "https://github.com/hi-ogawa/js-utils/tree/main/packages/utils-node",
   "repository": {
     "type": "git",

--- a/packages/utils-node/package.json
+++ b/packages/utils-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/utils-node",
-  "version": "0.0.1-pre.14",
+  "version": "0.0.1-pre.15",
   "homepage": "https://github.com/hi-ogawa/js-utils/tree/main/packages/utils-node",
   "repository": {
     "type": "git",

--- a/packages/utils-node/src/http.test.ts
+++ b/packages/utils-node/src/http.test.ts
@@ -1,32 +1,111 @@
 import { createServer } from "node:http";
-import { tinyassert } from "@hiogawa/utils";
-import { describe, expect, test } from "vitest";
-import { webToNodeHandler } from "./http";
+import { createManualPromise, tinyassert } from "@hiogawa/utils";
+import { describe, expect, test, vi } from "vitest";
+import { type WebHandler, webToNodeHandler } from "./http";
 
 describe(webToNodeHandler, () => {
   test("basic", async () => {
-    const handler = webToNodeHandler((request) => {
-      return new Response("hello = " + new URL(request.url).pathname, {
+    const abortFn = vi.fn();
+    await using server = await testWebHandler((request) => {
+      request.signal.addEventListener("abort", () => {
+        abortFn("abort");
+      });
+      const body = "hello = " + new URL(request.url).pathname;
+      return new Response(body, {
         headers: { "content-type": "text/x-hello" },
       });
     });
-    await using server = await testServer(
-      createServer((req, res) =>
-        handler(req, res, (e) => {
-          console.error(e);
-          res.end("[next]");
-        })
-      )
-    );
     const res = await fetch(server.url + "/abc");
+
+    expect(server.nextFn.mock.calls).toMatchInlineSnapshot(`[]`);
+    expect(abortFn.mock.calls).toMatchInlineSnapshot(`[]`);
     expect(res.headers.get("content-type")).toMatchInlineSnapshot(
       `"text/x-hello"`
     );
     expect(await res.text()).toMatchInlineSnapshot(`"hello = /abc"`);
   });
+
+  test("stream", async () => {
+    // https://github.com/hi-ogawa/reproductions/pull/9
+
+    const trackFn = vi.fn();
+    const abortPromise = createManualPromise<void>();
+    const cancelPromise = createManualPromise<void>();
+    async function handler(req: Request) {
+      let aborted = false;
+      req.signal.addEventListener("abort", () => {
+        trackFn("abort");
+        abortPromise.resolve();
+        aborted = true;
+      });
+
+      let cancelled = false;
+      const stream = new ReadableStream<string>({
+        async start(controller) {
+          for (let i = 0; !aborted && !cancelled; i++) {
+            controller.enqueue(`i = ${i}\n`);
+            await new Promise((resolve) => setTimeout(resolve, 200));
+          }
+          controller.close();
+        },
+        cancel() {
+          // cancel is not called
+          trackFn("cancel");
+          cancelPromise.resolve();
+          cancelled = true;
+        },
+      });
+
+      return new Response(stream.pipeThrough(new TextEncoderStream()));
+    }
+
+    await using server = await testWebHandler(handler);
+    const abortController = new AbortController();
+    const res = await fetch(server.url, { signal: abortController.signal });
+    tinyassert(res.ok);
+    tinyassert(res.body);
+    const chunks: string[] = [];
+    const promise = res.body.pipeThrough(new TextDecoderStream()).pipeTo(
+      new WritableStream({
+        write(chunk) {
+          chunks.push(chunk);
+          if (chunk.includes("i = 2")) {
+            abortController.abort();
+          }
+        },
+      })
+    );
+    await expect(promise).rejects.toMatchInlineSnapshot(
+      `[AbortError: This operation was aborted]`
+    );
+    expect(chunks).toMatchInlineSnapshot(`
+      [
+        "i = 0
+      ",
+        "i = 1
+      ",
+        "i = 2
+      ",
+      ]
+    `);
+    await abortPromise;
+    expect(trackFn.mock.calls).toMatchInlineSnapshot(`
+      [
+        [
+          "abort",
+        ],
+      ]
+    `);
+    expect(server.nextFn.mock.calls).toMatchInlineSnapshot(`[]`);
+  });
 });
 
-export async function testServer(server: import("node:http").Server) {
+async function testWebHandler(handler: WebHandler) {
+  // node server
+  const nextFn = vi.fn();
+  const nodeHandler = webToNodeHandler(handler);
+  const server = createServer((req, res) => nodeHandler(req, res, nextFn));
+
   // listen
   await new Promise<void>((resolve) => server.listen(() => resolve()));
 
@@ -37,8 +116,8 @@ export async function testServer(server: import("node:http").Server) {
   const url = `http://localhost:${address.port}`;
 
   return {
-    server,
     url,
+    nextFn,
     [Symbol.asyncDispose]: () => server[Symbol.asyncDispose](),
   };
 }

--- a/packages/utils-node/src/http.test.ts
+++ b/packages/utils-node/src/http.test.ts
@@ -1,0 +1,37 @@
+import { createServer } from "node:http";
+import { tinyassert } from "@hiogawa/utils";
+import { describe, expect, test } from "vitest";
+import { webToNodeHandler } from "./http";
+
+describe(webToNodeHandler, () => {
+  test("basic", async () => {
+    const handler = webToNodeHandler((request) => {
+      return new Response("hello = " + request.url, {
+        headers: { "content-type": "text/x-hello" },
+      });
+    });
+    await using server = await testServer(
+      createServer((req, res) => handler(req, res, () => res.end("[next]")))
+    );
+    const res = await fetch(server.url);
+    expect(res.headers.get("content-type")).toMatchInlineSnapshot(`null`);
+    expect(await res.text()).toMatchInlineSnapshot(`"[next]"`);
+  });
+});
+
+export async function testServer(server: import("node:http").Server) {
+  // listen
+  await new Promise<void>((resolve) => server.listen(() => resolve()));
+
+  // get address
+  const address = server.address();
+  tinyassert(address);
+  tinyassert(typeof address !== "string");
+  const url = `http://localhost:${address.port}`;
+
+  return {
+    server,
+    url,
+    [Symbol.asyncDispose]: () => server[Symbol.asyncDispose](),
+  };
+}

--- a/packages/utils-node/src/http.test.ts
+++ b/packages/utils-node/src/http.test.ts
@@ -49,7 +49,6 @@ describe(webToNodeHandler, () => {
           controller.close();
         },
         cancel() {
-          // cancel is not called
           trackFn("cancel");
           cancelPromise.resolve();
           cancelled = true;
@@ -88,11 +87,14 @@ describe(webToNodeHandler, () => {
       ",
       ]
     `);
-    await abortPromise;
+    await Promise.all([abortPromise, cancelPromise]);
     expect(trackFn.mock.calls).toMatchInlineSnapshot(`
       [
         [
           "abort",
+        ],
+        [
+          "cancel",
         ],
       ]
     `);

--- a/packages/utils-node/src/http.ts
+++ b/packages/utils-node/src/http.ts
@@ -1,0 +1,85 @@
+import type http from "node:http";
+import { Readable } from "node:stream";
+
+// https://github.com/hattipjs/hattip/blob/69237d181300b200a14114df2c3c115c44e0f3eb/packages/adapter/adapter-node/src/common.ts
+// https://github.com/remix-run/remix/blob/6eb6acf3f065f4574fbc96e4e8879482ce77b560/packages/remix-express/server.ts
+// https://github.com/honojs/node-server/blob/becc420b5d4ea51977a8e5b12e945ceb09c2ee9a/src/listener.ts
+// https://github.com/Shopify/hydrogen/blob/adc840f584129968d1710d494d19165e6664a60d/packages/mini-oxygen/src/vite/utils.ts
+
+export type WebHandler = (
+  request: Request
+) => Response | undefined | Promise<Response | undefined>;
+
+export type NodeHandler = (
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  next: (error?: unknown) => void
+) => void;
+
+export function webToNodeHandler(handler: WebHandler): NodeHandler {
+  return async (req, res, next) => {
+    try {
+      const request = createRequest(req, res);
+      const response = await handler(request);
+      if (response) {
+        sendResponse(response, res);
+      } else {
+        next();
+      }
+    } catch (e) {
+      next(e);
+    }
+  };
+}
+
+function createRequest(
+  req: http.IncomingMessage,
+  res: http.ServerResponse
+): Request {
+  const abortController = new AbortController();
+  res.on("close", () => {
+    if (!req.destroyed) {
+      abortController.abort();
+    }
+  });
+
+  const headers = new Headers();
+  for (const [k, v] of Object.entries(req.headers)) {
+    // skip http2 pseudo header since it breaks undici
+    if (k.startsWith(":")) {
+      continue;
+    }
+    if (typeof v === "string") {
+      headers.set(k, v);
+    } else if (Array.isArray(v)) {
+      v.forEach((v) => headers.append(k, v));
+    }
+  }
+
+  return new Request(
+    new URL(req.url || "/", req.headers.host || "https://test.local"),
+    {
+      method: req.method,
+      body: Readable.toWeb(req) as any,
+      headers,
+      signal: abortController.signal,
+      // @ts-ignore required for undici ReadableStream body
+      duplex: "half",
+    }
+  );
+}
+
+function sendResponse(response: Response, res: http.ServerResponse) {
+  const headers = Object.fromEntries(response.headers);
+  if (headers["set-cookie"]) {
+    delete headers["set-cookie"];
+    res.setHeader("set-cookie", response.headers.getSetCookie());
+  }
+  res.writeHead(response.status, response.statusText, headers);
+
+  if (response.body) {
+    Readable.fromWeb(response.body as any).pipe(res);
+  } else {
+    res.end();
+  }
+}

--- a/packages/utils-node/src/http.ts
+++ b/packages/utils-node/src/http.ts
@@ -57,10 +57,13 @@ function createRequest(
   }
 
   return new Request(
-    new URL(req.url || "/", req.headers.host || "https://test.local"),
+    new URL(req.url || "/", `http://${req.headers.host || "unknown.local"}`),
     {
       method: req.method,
-      body: Readable.toWeb(req) as any,
+      body:
+        req.method === "GET" || req.method === "HEAD"
+          ? null
+          : (Readable.toWeb(req) as any),
       headers,
       signal: abortController.signal,
       // @ts-ignore required for undici ReadableStream body

--- a/packages/utils-node/src/http.ts
+++ b/packages/utils-node/src/http.ts
@@ -38,7 +38,7 @@ function createRequest(
 ): Request {
   const abortController = new AbortController();
   res.on("close", () => {
-    if (!req.destroyed) {
+    if (req.destroyed) {
       abortController.abort();
     }
   });

--- a/packages/utils-node/src/index.ts
+++ b/packages/utils-node/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./script";
 export * from "./prompt";
 export * from "./parse-args";
+export * from "./http";

--- a/packages/utils-node/vitest.config.ts
+++ b/packages/utils-node/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  esbuild: {
+    // transpile `using`
+    target: "es2022",
+  },
+});


### PR DESCRIPTION
references

- https://github.com/hattipjs/hattip/blob/69237d181300b200a14114df2c3c115c44e0f3eb/packages/adapter/adapter-node/src/common.ts
- https://github.com/remix-run/remix/blob/6eb6acf3f065f4574fbc96e4e8879482ce77b560/packages/remix-express/server.ts
- https://github.com/honojs/node-server/blob/becc420b5d4ea51977a8e5b12e945ceb09c2ee9a/src/listener.ts
- https://github.com/Shopify/hydrogen/blob/adc840f584129968d1710d494d19165e6664a60d/packages/mini-oxygen/src/vite/utils.ts