### PR TITLE
fix(utils-node): cancel stream on error

### DIFF
--- a/packages/utils-node/src/http.test.ts
+++ b/packages/utils-node/src/http.test.ts
@@ -25,7 +25,7 @@ describe(webToNodeHandler, () => {
     expect(await res.text()).toMatchInlineSnapshot(`"hello = /abc"`);
   });
 
-  test("stream", async () => {
+  test("stream abort", async () => {
     // https://github.com/hi-ogawa/reproductions/pull/9
 
     const trackFn = vi.fn();
@@ -98,6 +98,63 @@ describe(webToNodeHandler, () => {
         ],
       ]
     `);
+    expect(server.nextFn.mock.calls).toMatchInlineSnapshot(`[]`);
+  });
+
+  test("stream close itself", async () => {
+    const trackFn = vi.fn();
+    const abortPromise = createManualPromise<void>();
+    const cancelPromise = createManualPromise<void>();
+    async function handler(req: Request) {
+      let aborted = false;
+      req.signal.addEventListener("abort", () => {
+        trackFn("abort");
+        abortPromise.resolve();
+        aborted = true;
+      });
+
+      let cancelled = false;
+      const stream = new ReadableStream<string>({
+        async start(controller) {
+          for (let i = 0; i < 3; i++) {
+            controller.enqueue(`i = ${i}\n`);
+            await new Promise((resolve) => setTimeout(resolve, 200));
+          }
+          controller.close();
+        },
+        cancel() {
+          trackFn("cancel");
+          cancelPromise.resolve();
+          cancelled = true;
+        },
+      });
+
+      return new Response(stream.pipeThrough(new TextEncoderStream()));
+    }
+
+    await using server = await testWebHandler(handler);
+    const res = await fetch(server.url);
+    tinyassert(res.ok);
+    tinyassert(res.body);
+    const chunks: string[] = [];
+    await res.body.pipeThrough(new TextDecoderStream()).pipeTo(
+      new WritableStream({
+        write(chunk) {
+          chunks.push(chunk);
+        },
+      })
+    );
+    expect(chunks).toMatchInlineSnapshot(`
+      [
+        "i = 0
+      ",
+        "i = 1
+      ",
+        "i = 2
+      ",
+      ]
+    `);
+    expect(trackFn.mock.calls).toMatchInlineSnapshot(`[]`);
     expect(server.nextFn.mock.calls).toMatchInlineSnapshot(`[]`);
   });
 });

--- a/packages/utils-node/src/http.test.ts
+++ b/packages/utils-node/src/http.test.ts
@@ -106,14 +106,11 @@ describe(webToNodeHandler, () => {
     const abortPromise = createManualPromise<void>();
     const cancelPromise = createManualPromise<void>();
     async function handler(req: Request) {
-      let aborted = false;
       req.signal.addEventListener("abort", () => {
         trackFn("abort");
         abortPromise.resolve();
-        aborted = true;
       });
 
-      let cancelled = false;
       const stream = new ReadableStream<string>({
         async start(controller) {
           for (let i = 0; i < 3; i++) {
@@ -125,7 +122,6 @@ describe(webToNodeHandler, () => {
         cancel() {
           trackFn("cancel");
           cancelPromise.resolve();
-          cancelled = true;
         },
       });
 

--- a/packages/utils-node/src/http.ts
+++ b/packages/utils-node/src/http.ts
@@ -83,14 +83,13 @@ function sendResponse(response: Response, res: http.ServerResponse) {
   }
   res.writeHead(response.status, response.statusText, headers);
 
-  const body = response.body;
-  if (body) {
+  if (response.body) {
     const abortController = new AbortController();
     res.once("close", () => abortController.abort());
-    const nodeBody = Readable.fromWeb(body as any, {
+    res.once("error", () => abortController.abort());
+    Readable.fromWeb(response.body as any, {
       signal: abortController.signal,
-    });
-    nodeBody.pipe(res);
+    }).pipe(res);
   } else {
     res.end();
   }


### PR DESCRIPTION
I noticed there's another possibility to flip the web/node world.

```ts
Readable.fromWeb(response.body).pipe(res)
response.body.pipeTo(Writable.toWeb(res))
```

Both seems to be working mostly same, but for now let's just go with the former.