### PR TITLE
refactor(tiny-refresh): unify code for vite and webpack

### DIFF
--- a/packages/tiny-react/src/hmr/index.test.tsx
+++ b/packages/tiny-react/src/hmr/index.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { type ViteHot, setupVite } from ".";
+import { type ViteHot, initialize } from ".";
 import { useEffect, useReducer } from "../hooks";
 import { render } from "../reconciler";
 import { sleepFrame } from "../test-utils";
@@ -45,7 +45,7 @@ describe("hmr", () => {
         return <div>1</div>;
       }
 
-      const manager = setupVite(hot, runtime, false);
+      const manager = initialize(hot, runtime, { mode: "vite", debug: false });
       ChildExport = manager.wrap("Child", Child, "useEffect");
       manager.setup();
     }
@@ -78,7 +78,7 @@ describe("hmr", () => {
         return <div>2</div>;
       }
 
-      const manager = setupVite(hot, runtime, false);
+      const manager = initialize(hot, runtime, { mode: "vite", debug: false });
       manager.wrap("Child", Child, "");
       manager.setup();
     }
@@ -119,7 +119,7 @@ describe("hmr", () => {
         return <div>3</div>;
       }
 
-      const manager = setupVite(hot, runtime, false);
+      const manager = initialize(hot, runtime, { mode: "vite", debug: false });
       manager.wrap("Child", Child, "useEffect");
       manager.setup();
     }

--- a/packages/tiny-react/src/hmr/index.test.tsx
+++ b/packages/tiny-react/src/hmr/index.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { type ViteHot, createManager } from ".";
+import { type ViteHot, setupVite } from ".";
 import { useEffect, useReducer } from "../hooks";
 import { render } from "../reconciler";
 import { sleepFrame } from "../test-utils";
@@ -45,9 +45,8 @@ describe("hmr", () => {
         return <div>1</div>;
       }
 
-      const manager = createManager(hot, runtime, false);
+      const manager = setupVite(hot, runtime, false);
       ChildExport = manager.wrap("Child", Child, "useEffect");
-      manager.setup();
     }
 
     const vnode = <Parent />;
@@ -78,9 +77,8 @@ describe("hmr", () => {
         return <div>2</div>;
       }
 
-      const manager = createManager(hot, runtime, false);
+      const manager = setupVite(hot, runtime, false);
       manager.wrap("Child", Child, "");
-      manager.setup();
     }
 
     // simulate 1st version's `hot.accept`
@@ -119,9 +117,8 @@ describe("hmr", () => {
         return <div>3</div>;
       }
 
-      const manager = createManager(hot, runtime, false);
+      const manager = setupVite(hot, runtime, false);
       manager.wrap("Child", Child, "useEffect");
-      manager.setup();
     }
 
     acceptCallbacks[1]({});

--- a/packages/tiny-react/src/hmr/index.test.tsx
+++ b/packages/tiny-react/src/hmr/index.test.tsx
@@ -47,6 +47,7 @@ describe("hmr", () => {
 
       const manager = setupVite(hot, runtime, false);
       ChildExport = manager.wrap("Child", Child, "useEffect");
+      manager.setup();
     }
 
     const vnode = <Parent />;
@@ -79,6 +80,7 @@ describe("hmr", () => {
 
       const manager = setupVite(hot, runtime, false);
       manager.wrap("Child", Child, "");
+      manager.setup();
     }
 
     // simulate 1st version's `hot.accept`
@@ -119,6 +121,7 @@ describe("hmr", () => {
 
       const manager = setupVite(hot, runtime, false);
       manager.wrap("Child", Child, "useEffect");
+      manager.setup();
     }
 
     acceptCallbacks[1]({});

--- a/packages/tiny-refresh/src/runtime.test.tsx
+++ b/packages/tiny-refresh/src/runtime.test.tsx
@@ -3,7 +3,7 @@
 import { act, cleanup, render } from "@testing-library/react";
 import React from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { type ViteHot, setupVite } from "./runtime";
+import { type ViteHot, initialize } from "./runtime";
 
 afterEach(cleanup);
 
@@ -37,7 +37,7 @@ describe("hmr", () => {
         return <div>1</div>;
       }
 
-      const manager = setupVite(hot, React, false);
+      const manager = initialize(hot, React, { mode: "vite", debug: false });
       ChildExport = manager.wrap("Child", Child, "useEffect");
       manager.setup();
     }
@@ -70,7 +70,7 @@ describe("hmr", () => {
       function Child() {
         return <div>2</div>;
       }
-      const manager = setupVite(hot, React, false);
+      const manager = initialize(hot, React, { mode: "vite", debug: false });
       manager.wrap("Child", Child, "");
       manager.setup();
     }
@@ -111,7 +111,7 @@ describe("hmr", () => {
         return <div>3</div>;
       }
 
-      const manager = setupVite(hot, React, false);
+      const manager = initialize(hot, React, { mode: "vite", debug: false });
       manager.wrap("Child", Child, "useEffect");
       manager.setup();
     }
@@ -154,7 +154,7 @@ describe("hmr", () => {
         return <div>4</div>;
       }
 
-      const manager = setupVite(hot, React, false);
+      const manager = initialize(hot, React, { mode: "vite", debug: false });
       manager.wrap("Child", Child, "useEffect");
       manager.setup();
     }
@@ -191,7 +191,7 @@ describe("hmr", () => {
         return <div>5</div>;
       }
 
-      const manager = setupVite(hot, React, false);
+      const manager = initialize(hot, React, { mode: "vite", debug: false });
       manager.wrap("Child", Child, "");
       manager.setup();
     }

--- a/packages/tiny-refresh/src/runtime.test.tsx
+++ b/packages/tiny-refresh/src/runtime.test.tsx
@@ -39,6 +39,7 @@ describe("hmr", () => {
 
       const manager = setupVite(hot, React, false);
       ChildExport = manager.wrap("Child", Child, "useEffect");
+      manager.setup();
     }
 
     function Parent() {
@@ -71,6 +72,7 @@ describe("hmr", () => {
       }
       const manager = setupVite(hot, React, false);
       manager.wrap("Child", Child, "");
+      manager.setup();
     }
 
     // simulate last version's `hot.accept`
@@ -111,6 +113,7 @@ describe("hmr", () => {
 
       const manager = setupVite(hot, React, false);
       manager.wrap("Child", Child, "useEffect");
+      manager.setup();
     }
 
     act(() => acceptCallbacks[1]({}));
@@ -153,6 +156,7 @@ describe("hmr", () => {
 
       const manager = setupVite(hot, React, false);
       manager.wrap("Child", Child, "useEffect");
+      manager.setup();
     }
 
     act(() => acceptCallbacks[1]({}));
@@ -189,6 +193,7 @@ describe("hmr", () => {
 
       const manager = setupVite(hot, React, false);
       manager.wrap("Child", Child, "");
+      manager.setup();
     }
 
     act(() => acceptCallbacks[1]({}));

--- a/packages/tiny-refresh/src/runtime.test.tsx
+++ b/packages/tiny-refresh/src/runtime.test.tsx
@@ -3,7 +3,7 @@
 import { act, cleanup, render } from "@testing-library/react";
 import React from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { type ViteHot, createManager } from "./runtime";
+import { type ViteHot, setupVite } from "./runtime";
 
 afterEach(cleanup);
 
@@ -37,9 +37,8 @@ describe("hmr", () => {
         return <div>1</div>;
       }
 
-      const manager = createManager(hot, React, false);
+      const manager = setupVite(hot, React, false);
       ChildExport = manager.wrap("Child", Child, "useEffect");
-      manager.setup();
     }
 
     function Parent() {
@@ -70,9 +69,8 @@ describe("hmr", () => {
       function Child() {
         return <div>2</div>;
       }
-      const manager = createManager(hot, React, false);
+      const manager = setupVite(hot, React, false);
       manager.wrap("Child", Child, "");
-      manager.setup();
     }
 
     // simulate last version's `hot.accept`
@@ -111,9 +109,8 @@ describe("hmr", () => {
         return <div>3</div>;
       }
 
-      const manager = createManager(hot, React, false);
+      const manager = setupVite(hot, React, false);
       manager.wrap("Child", Child, "useEffect");
-      manager.setup();
     }
 
     act(() => acceptCallbacks[1]({}));
@@ -154,9 +151,8 @@ describe("hmr", () => {
         return <div>4</div>;
       }
 
-      const manager = createManager(hot, React, false);
+      const manager = setupVite(hot, React, false);
       manager.wrap("Child", Child, "useEffect");
-      manager.setup();
     }
 
     act(() => acceptCallbacks[1]({}));
@@ -191,9 +187,8 @@ describe("hmr", () => {
         return <div>5</div>;
       }
 
-      const manager = createManager(hot, React, false);
+      const manager = setupVite(hot, React, false);
       manager.wrap("Child", Child, "");
-      manager.setup();
     }
 
     act(() => acceptCallbacks[1]({}));

--- a/packages/tiny-refresh/src/runtime.ts
+++ b/packages/tiny-refresh/src/runtime.ts
@@ -119,6 +119,10 @@ function createProxyComponent(manager: Manager, name: string): ProxyEntry {
   return { Component, listeners };
 }
 
+//
+// hmr api integration
+//
+
 export function setupVite(hot: ViteHot, runtime: Runtime, debug?: boolean) {
   const manager = (hot.data[MANAGER_KEY] ??= new Manager({ runtime, debug }));
 
@@ -143,10 +147,10 @@ export function setupWebpack(
   const prevData = hot.data?.[MANAGER_KEY];
   const manager = prevData ?? new Manager({ runtime, debug });
 
+  hot.accept();
   hot.dispose((data) => {
     data[MANAGER_KEY] = manager;
   });
-  hot.accept();
 
   function onFinished() {
     if (prevData && !manager.patch()) {

--- a/packages/tiny-refresh/src/runtime.ts
+++ b/packages/tiny-refresh/src/runtime.ts
@@ -39,6 +39,7 @@ interface ComponentEntry {
 class Manager {
   public proxyMap = new Map<string, ProxyEntry>();
   public componentMap = new Map<string, ComponentEntry>();
+  public finish = () => {};
 
   constructor(
     public options: {
@@ -152,11 +153,11 @@ export function setupWebpack(
     data[MANAGER_KEY] = manager;
   });
 
-  function onFinished() {
+  manager.finish = () => {
     if (prevData && !manager.patch()) {
       hot.invalidate();
     }
-  }
+  };
 
-  return [manager, onFinished];
+  return manager;
 }

--- a/packages/tiny-refresh/src/runtime.ts
+++ b/packages/tiny-refresh/src/runtime.ts
@@ -1,12 +1,12 @@
-export const MANAGER_KEY = Symbol.for("tiny-refresh.manager");
+const MANAGER_KEY = Symbol.for("tiny-refresh.manager");
 
-export interface ViteHot {
+interface ViteHot {
   accept: (onNewModule: (newModule?: unknown) => void) => void;
   invalidate: (message?: string) => void;
   data: HotData;
 }
 
-export interface WebpackHot {
+interface WebpackHot {
   accept: (cb?: () => void) => void;
   invalidate: () => void;
   dispose: (cb: (data: HotData) => void) => void;

--- a/packages/tiny-refresh/src/runtime.ts
+++ b/packages/tiny-refresh/src/runtime.ts
@@ -39,7 +39,7 @@ interface ComponentEntry {
 class Manager {
   public proxyMap = new Map<string, ProxyEntry>();
   public componentMap = new Map<string, ComponentEntry>();
-  public finish = () => {};
+  public setup = () => {};
 
   constructor(
     public options: {
@@ -153,7 +153,7 @@ export function setupWebpack(
     data[MANAGER_KEY] = manager;
   });
 
-  manager.finish = () => {
+  manager.setup = () => {
     if (prevData && !manager.patch()) {
       hot.invalidate();
     }

--- a/packages/tiny-refresh/src/runtime.ts
+++ b/packages/tiny-refresh/src/runtime.ts
@@ -1,6 +1,6 @@
 const MANAGER_KEY = Symbol.for("tiny-refresh.manager");
 
-interface ViteHot {
+export interface ViteHot {
   accept: (onNewModule: (newModule?: unknown) => void) => void;
   invalidate: (message?: string) => void;
   data: HotData;

--- a/packages/tiny-refresh/src/transform.test.ts
+++ b/packages/tiny-refresh/src/transform.test.ts
@@ -60,7 +60,7 @@ const NotFn = "hello";
       import * as $$refresh from "/refresh-runtime";
       if (import.meta.hot) {
         () => import.meta.hot.accept(); // need a fake "accept" for Vite to notice
-        const $$manager = $$runtime.setupVite(
+        const $$manager = $$refresh.setupVite(
           import.meta.hot,
           $$runtime,
           false

--- a/packages/tiny-refresh/src/transform.test.ts
+++ b/packages/tiny-refresh/src/transform.test.ts
@@ -69,6 +69,7 @@ const NotFn = "hello";
         FnLet = $$manager.wrap("FnLet", FnLet, "useState/useRef/useCallback");
         FnConst = $$manager.wrap("FnConst", FnConst, "");
         FnNonExport = $$manager.wrap("FnNonExport", FnNonExport, "");
+        $$manager.finish();
       }"
     `);
   });

--- a/packages/tiny-refresh/src/transform.test.ts
+++ b/packages/tiny-refresh/src/transform.test.ts
@@ -59,23 +59,17 @@ const NotFn = "hello";
       import * as $$runtime from "/runtime";
       import * as $$refresh from "/refresh-runtime";
       if (import.meta.hot) {
-        () => import.meta.hot.accept();
-        const $$manager = $$refresh.createManager(
+        () => import.meta.hot.accept(); // need a fake "accept" for Vite to notice
+        const $$manager = $$runtime.setupVite(
           import.meta.hot,
-          {
-            createElement: $$runtime.createElement,
-            useReducer: $$runtime.useReducer,
-            useEffect: $$runtime.useEffect,
-          },
-          false,
+          $$runtime,
+          false
         );
         FnDefault = $$manager.wrap("FnDefault", FnDefault, "");
         FnLet = $$manager.wrap("FnLet", FnLet, "useState/useRef/useCallback");
         FnConst = $$manager.wrap("FnConst", FnConst, "");
         FnNonExport = $$manager.wrap("FnNonExport", FnNonExport, "");
-        $$manager.setup();
-      }
-      "
+      }"
     `);
   });
 });

--- a/packages/tiny-refresh/src/transform.test.ts
+++ b/packages/tiny-refresh/src/transform.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
-import { transformVite } from "./transform";
+import { transform } from "./transform";
 
-describe(transformVite, () => {
+describe(transform, () => {
   it("basic", async () => {
     const input = /* js */ `\
 
@@ -28,9 +28,11 @@ const NotFn = "hello";
 // export const NotFn2 = "hello";
 `;
     expect(
-      await transformVite(input, {
+      await transform(input, {
         runtime: "/runtime",
         refreshRuntime: "/refresh-runtime",
+        mode: "vite",
+        debug: false,
       })
     ).toMatchInlineSnapshot(`
       "
@@ -59,18 +61,21 @@ const NotFn = "hello";
       import * as $$runtime from "/runtime";
       import * as $$refresh from "/refresh-runtime";
       if (import.meta.hot) {
-        () => import.meta.hot.accept(); // need a fake "accept" for Vite to notice
-        const $$manager = $$refresh.setupVite(
+        (() => import.meta.hot.accept());
+        const $$manager = $$refresh.initialize(
           import.meta.hot,
           $$runtime,
-          false
+          {"runtime":"/runtime","refreshRuntime":"/refresh-runtime","mode":"vite","debug":false}
         );
+
         FnDefault = $$manager.wrap("FnDefault", FnDefault, "");
         FnLet = $$manager.wrap("FnLet", FnLet, "useState/useRef/useCallback");
         FnConst = $$manager.wrap("FnConst", FnConst, "");
         FnNonExport = $$manager.wrap("FnNonExport", FnNonExport, "");
+
         $$manager.setup();
-      }"
+      }
+      "
     `);
   });
 });

--- a/packages/tiny-refresh/src/transform.test.ts
+++ b/packages/tiny-refresh/src/transform.test.ts
@@ -69,7 +69,7 @@ const NotFn = "hello";
         FnLet = $$manager.wrap("FnLet", FnLet, "useState/useRef/useCallback");
         FnConst = $$manager.wrap("FnConst", FnConst, "");
         FnNonExport = $$manager.wrap("FnNonExport", FnNonExport, "");
-        $$manager.finish();
+        $$manager.setup();
       }"
     `);
   });

--- a/packages/tiny-refresh/src/transform.test.ts
+++ b/packages/tiny-refresh/src/transform.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
-import { hmrTransform } from "./transform";
+import { transformVite } from "./transform";
 
-describe(hmrTransform, () => {
+describe(transformVite, () => {
   it("basic", async () => {
     const input = /* js */ `\
 
@@ -28,7 +28,7 @@ const NotFn = "hello";
 // export const NotFn2 = "hello";
 `;
     expect(
-      await hmrTransform(input, {
+      await transformVite(input, {
         runtime: "/runtime",
         refreshRuntime: "/refresh-runtime",
       })

--- a/packages/tiny-refresh/src/transform.ts
+++ b/packages/tiny-refresh/src/transform.ts
@@ -30,6 +30,8 @@ if (import.meta.hot) {
   ${id} = $$manager.wrap("${id}", ${id}, ${JSON.stringify(hooks.join("/"))});
 `;
   }
+  footer += `\
+}`;
   // no need to manipulate sourcemap since transform only appends
   return result.outCode + footer;
 }

--- a/packages/tiny-refresh/src/transform.ts
+++ b/packages/tiny-refresh/src/transform.ts
@@ -1,13 +1,13 @@
 import type * as estree from "estree";
 import { parseAstAsync } from "vite";
 
-interface HmrTransformOptions {
+interface TransformOptions {
   runtime: string; // e.g. "react", "preact/compat", "@hiogawa/tiny-react"
   refreshRuntime: string; // allow "@hiogawa/tiny-react" to re-export refresh runtime by itself to simplify dependency
   debug?: boolean;
 }
 
-export async function transformVite(code: string, options: HmrTransformOptions) {
+export async function transformVite(code: string, options: TransformOptions) {
   const result = await analyzeCode(code);
   if (result.errors.length || result.entries.length === 0) {
     return;
@@ -43,7 +43,7 @@ if (import.meta.hot) {
 // TODO: refactor with transformVite/Webpack
 export async function transformWebpack(
   code: string,
-  options: HmrTransformOptions
+  options: TransformOptions
 ) {
   const result = await analyzeCode(code);
   if (result.errors.length || result.entries.length === 0) {

--- a/packages/tiny-refresh/src/transform.ts
+++ b/packages/tiny-refresh/src/transform.ts
@@ -36,7 +36,6 @@ if (import.meta.hot) {
   return result.outCode + footer;
 }
 
-// TODO: refactor with transformVite/Webpack
 export async function transformWebpack(
   code: string,
   options: TransformOptions
@@ -90,8 +89,6 @@ const COMPONENT_RE = /^[A-Z]/;
 async function analyzeCode(code: string) {
   const ast = await parseAstAsync(code);
   const errors: unknown[] = [];
-
-  // TODO: collect also non-exported functions with a capitalized names
   const entries: ParsedEntry[] = [];
 
   // replace "export const" with "export let"

--- a/packages/tiny-refresh/src/transform.ts
+++ b/packages/tiny-refresh/src/transform.ts
@@ -31,7 +31,7 @@ if (import.meta.hot) {
 `;
   }
   footer += `\
-  $$manager.finish();
+  $$manager.setup();
 }`;
   // no need to manipulate sourcemap since transform only appends
   return result.outCode + footer;
@@ -61,7 +61,7 @@ if (import.meta.webpackHot) {
 `;
   }
   footer += `\
-  $$manager.finish();
+  $$manager.setup();
 }
 `;
   return result.outCode + footer;

--- a/packages/tiny-refresh/src/transform.ts
+++ b/packages/tiny-refresh/src/transform.ts
@@ -19,7 +19,7 @@ import * as $$runtime from "${options.runtime}";
 import * as $$refresh from "${options.refreshRuntime}";
 if (import.meta.hot) {
   () => import.meta.hot.accept(); // need a fake "accept" for Vite to notice
-  const $$manager = $$runtime.setupVite(
+  const $$manager = $$refresh.setupVite(
     import.meta.hot,
     $$runtime,
     ${options.debug ?? false}
@@ -49,7 +49,7 @@ export async function transformWebpack(
 import * as $$runtime from "${options.runtime}";
 import * as $$refresh from "${options.refreshRuntime}";
 if (import.meta.webpackHot) {
-  const [$$manager, $$finish] = $$runtime.setupWebpack(
+  const [$$manager, $$finish] = $$refresh.setupWebpack(
     import.meta.webpackHot,
     $$runtime,
     ${options.debug ?? false},

--- a/packages/tiny-refresh/src/transform.ts
+++ b/packages/tiny-refresh/src/transform.ts
@@ -7,7 +7,7 @@ interface HmrTransformOptions {
   debug?: boolean;
 }
 
-export async function hmrTransform(code: string, options: HmrTransformOptions) {
+export async function transformVite(code: string, options: HmrTransformOptions) {
   const result = await analyzeCode(code);
   if (result.errors.length || result.entries.length === 0) {
     return;

--- a/packages/tiny-refresh/src/transform.ts
+++ b/packages/tiny-refresh/src/transform.ts
@@ -61,7 +61,7 @@ if (import.meta.webpackHot) {
 `;
   }
   footer += `\
-  $$fininsh();
+  $$finish();
 }
 `;
   return result.outCode + footer;

--- a/packages/tiny-refresh/src/transform.ts
+++ b/packages/tiny-refresh/src/transform.ts
@@ -31,6 +31,7 @@ if (import.meta.hot) {
 `;
   }
   footer += `\
+  $$manager.finish();
 }`;
   // no need to manipulate sourcemap since transform only appends
   return result.outCode + footer;
@@ -48,7 +49,7 @@ export async function transformWebpack(
 import * as $$runtime from "${options.runtime}";
 import * as $$refresh from "${options.refreshRuntime}";
 if (import.meta.webpackHot) {
-  const [$$manager, $$finish] = $$refresh.setupWebpack(
+  const $$manager = $$refresh.setupWebpack(
     import.meta.webpackHot,
     $$runtime,
     ${options.debug ?? false},
@@ -60,7 +61,7 @@ if (import.meta.webpackHot) {
 `;
   }
   footer += `\
-  $$finish();
+  $$manager.finish();
 }
 `;
   return result.outCode + footer;

--- a/packages/tiny-refresh/src/transform.ts
+++ b/packages/tiny-refresh/src/transform.ts
@@ -40,6 +40,7 @@ if (import.meta.hot) {
   return result.outCode + footer;
 }
 
+// TODO: refactor with transformVite/Webpack
 export async function transformWebpack(
   code: string,
   options: HmrTransformOptions

--- a/packages/tiny-refresh/src/vite.ts
+++ b/packages/tiny-refresh/src/vite.ts
@@ -1,5 +1,5 @@
 import { type FilterPattern, type Plugin, createFilter } from "vite";
-import { transformVite } from "./transform";
+import { transform } from "./transform";
 
 export function vitePluginTinyRefresh(options?: {
   include?: FilterPattern;
@@ -17,9 +17,10 @@ export function vitePluginTinyRefresh(options?: {
     apply: "serve",
     transform(code, id, transformOptions) {
       if (!transformOptions?.ssr && filter(id)) {
-        return transformVite(code, {
+        return transform(code, {
           runtime: options?.runtime ?? "react",
           refreshRuntime: options?.refreshRuntime ?? "@hiogawa/tiny-refresh",
+          mode: "vite",
           debug: true,
         });
       }

--- a/packages/tiny-refresh/src/vite.ts
+++ b/packages/tiny-refresh/src/vite.ts
@@ -1,5 +1,5 @@
 import { type FilterPattern, type Plugin, createFilter } from "vite";
-import { hmrTransform } from "./transform";
+import { transformVite } from "./transform";
 
 export function vitePluginTinyRefresh(options?: {
   include?: FilterPattern;
@@ -17,7 +17,7 @@ export function vitePluginTinyRefresh(options?: {
     apply: "serve",
     transform(code, id, transformOptions) {
       if (!transformOptions?.ssr && filter(id)) {
-        return hmrTransform(code, {
+        return transformVite(code, {
           runtime: options?.runtime ?? "react",
           refreshRuntime: options?.refreshRuntime ?? "@hiogawa/tiny-refresh",
           debug: true,

--- a/packages/tiny-refresh/src/webpack.ts
+++ b/packages/tiny-refresh/src/webpack.ts
@@ -1,4 +1,4 @@
-import { transformWebpack } from "./transform";
+import { transform } from "./transform";
 
 export type TinyRefreshLoaderOptions = {
   refreshRuntime?: string;
@@ -9,9 +9,10 @@ export type TinyRefreshLoaderOptions = {
 export default function loader(this: any, input: string) {
   const callback = this.async();
   const options = this.getOptions() as TinyRefreshLoaderOptions;
-  transformWebpack(input, {
+  transform(input, {
     refreshRuntime: options.refreshRuntime ?? "@hiogawa/tiny-refresh",
     runtime: "react",
+    mode: "webpack",
     debug: true,
   }).then(
     (result) => callback(null, result ?? input),


### PR DESCRIPTION
- follow up to https://github.com/hi-ogawa/js-utils/pull/261