### PR TITLE
feat(gh-bin): download progress

### DIFF
--- a/packages/gh-bin/CHANGELOG.md
+++ b/packages/gh-bin/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## v0.1.2 (2025-05-27)
+
+- feat(gh-bin): download progress

--- a/packages/gh-bin/README.md
+++ b/packages/gh-bin/README.md
@@ -19,7 +19,7 @@ $ npx gh-bin --help
 
 ```txt
 $ npx gh-bin --help
-gh-bin@0.1.1
+gh-bin@0.1.2
 
 Usage:
   npx gh-bin https://github.com/<owner>/<repo>

--- a/packages/gh-bin/package.json
+++ b/packages/gh-bin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gh-bin",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "homepage": "https://github.com/hi-ogawa/js-utils/tree/main/packages/gh-bin",
   "repository": {
     "type": "git",

--- a/packages/gh-bin/src/cli.ts
+++ b/packages/gh-bin/src/cli.ts
@@ -98,28 +98,26 @@ async function main() {
     const total = contentLength ? Number(contentLength) : null;
     let current = 0;
     const stream = res.body.pipeThrough(
-      new TransformStream(
-        {
-          transform(chunk, controller) {
-            controller.enqueue(chunk);
-            current += chunk.byteLength;
-            if (total) {
-              downloadSpinner.message(
-                `Downloading ${selectedAsset} (${prettyBytes(total)} - ${((100 * current) / total!).toFixed(2)}%)`
-              );
-            } else {
-              downloadSpinner.message(
-                `Downloading ${selectedAsset} (${prettyBytes(current)})`
-              );
-            }
-          },
-          flush() {
-            downloadSpinner.stop(
-              `Download success ${selectedAsset} (${prettyBytes(current)})`
+      new TransformStream({
+        transform(chunk, controller) {
+          controller.enqueue(chunk);
+          current += chunk.byteLength;
+          if (total) {
+            downloadSpinner.message(
+              `Downloading ${selectedAsset} (${prettyBytes(total)} - ${((100 * current) / total!).toFixed(2)}%)`
             );
-          },
-        }
-      )
+          } else {
+            downloadSpinner.message(
+              `Downloading ${selectedAsset} (${prettyBytes(current)})`
+            );
+          }
+        },
+        flush() {
+          downloadSpinner.stop(
+            `Download success ${selectedAsset} (${prettyBytes(current)})`
+          );
+        },
+      })
     );
     await fs.promises.writeFile(tmpAssetPath, Readable.fromWeb(stream as any));
   } catch (e) {

--- a/packages/gh-bin/src/cli.ts
+++ b/packages/gh-bin/src/cli.ts
@@ -90,10 +90,6 @@ async function main() {
       console.error(`[ERROR] Failed to download '${selectedAssetUrl}'\n`);
       process.exit(1);
     }
-    const prettyBytes = (bytes: number) =>
-      bytes > 1024 * 1024
-        ? `${(bytes / (1024 * 1024)).toFixed(2)} MB`
-        : `${(bytes / 1024).toFixed(2)} KB`;
     const contentLength = res.headers.get("content-length");
     const total = contentLength ? Number(contentLength) : null;
     let current = 0;
@@ -196,6 +192,12 @@ async function main() {
   await fs.promises.copyFile(tmpAssetPath, destPath);
   await fs.promises.chmod(destPath, 0o755);
   console.log(`Executable is installed in ${destPath}`);
+}
+
+function prettyBytes(bytes: number): string {
+  return bytes > 1024
+    ? `${(bytes / (1024 * 1024)).toFixed(2)} MB`
+    : `${(bytes / 1024).toFixed(2)} KB`;
 }
 
 async function fetchGhApi(url: string) {


### PR DESCRIPTION
I noticed flyctl binary downloading is super slow. Adding progress message to let users know it's not broken.
(Probably using range request might improve throughput, but that can be later for now)

https://github.com/user-attachments/assets/b292ce0d-bad5-4cf7-8e65-5e138959cdf1

